### PR TITLE
Introduce a new marker for quantities

### DIFF
--- a/UnitsNet.Tests/CustomCode/PressureFlowRateTests.cs
+++ b/UnitsNet.Tests/CustomCode/PressureFlowRateTests.cs
@@ -1,0 +1,40 @@
+﻿// Copyright © 2007 by Initial Force AS.  All rights reserved.
+// https://github.com/InitialForce/UnitsNet
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+
+using System;
+
+namespace UnitsNet.Tests.CustomCode
+{
+    public class PressureFlowRateTests : PressureFlowRateTestsBase
+    {
+
+        protected override double PascalsPerMinuteInOnePascalPerSecond
+        {
+            get { return 60; }
+        }
+
+        protected override double PascalsPerSecondInOnePascalPerSecond
+        {
+            get { return 1; }
+        }
+    }
+}

--- a/UnitsNet.Tests/GeneratedCode/PressureFlowRateTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/PressureFlowRateTestsBase.g.cs
@@ -1,0 +1,173 @@
+﻿// Copyright © 2007 by Initial Force AS.  All rights reserved.
+// https://github.com/InitialForce/UnitsNet
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using NUnit.Framework;
+using UnitsNet.Units;
+
+// Disable build warning CS1718: Comparison made to same variable; did you mean to compare something else?
+#pragma warning disable 1718
+
+// ReSharper disable once CheckNamespace
+namespace UnitsNet.Tests
+{
+    /// <summary>
+    /// Test of PressureFlowRate.
+    /// </summary>
+    [TestFixture]
+// ReSharper disable once PartialTypeWithSinglePart
+    public abstract partial class PressureFlowRateTestsBase
+    {
+        protected abstract double PascalsPerMinuteInOnePascalPerSecond { get; }
+        protected abstract double PascalsPerSecondInOnePascalPerSecond { get; }
+
+// ReSharper disable VirtualMemberNeverOverriden.Global
+        protected virtual double PascalsPerMinuteTolerance { get { return 1e-5; } }
+        protected virtual double PascalsPerSecondTolerance { get { return 1e-5; } }
+// ReSharper restore VirtualMemberNeverOverriden.Global
+
+        [Test]
+        public void PascalPerSecondToPressureFlowRateUnits()
+        {
+            PressureFlowRate pascalpersecond = PressureFlowRate.FromPascalsPerSecond(1);
+            Assert.AreEqual(PascalsPerMinuteInOnePascalPerSecond, pascalpersecond.PascalsPerMinute, PascalsPerMinuteTolerance);
+            Assert.AreEqual(PascalsPerSecondInOnePascalPerSecond, pascalpersecond.PascalsPerSecond, PascalsPerSecondTolerance);
+        }
+
+        [Test]
+        public void FromValueAndUnit()
+        {
+            Assert.AreEqual(1, PressureFlowRate.From(1, PressureFlowRateUnit.PascalPerMinute).PascalsPerMinute, PascalsPerMinuteTolerance);
+            Assert.AreEqual(1, PressureFlowRate.From(1, PressureFlowRateUnit.PascalPerSecond).PascalsPerSecond, PascalsPerSecondTolerance);
+        }
+
+        [Test]
+        public void As()
+        {
+            var pascalpersecond = PressureFlowRate.FromPascalsPerSecond(1);
+            Assert.AreEqual(PascalsPerMinuteInOnePascalPerSecond, pascalpersecond.As(PressureFlowRateUnit.PascalPerMinute), PascalsPerMinuteTolerance);
+            Assert.AreEqual(PascalsPerSecondInOnePascalPerSecond, pascalpersecond.As(PressureFlowRateUnit.PascalPerSecond), PascalsPerSecondTolerance);
+        }
+
+        [Test]
+        public void ConversionRoundTrip()
+        {
+            PressureFlowRate pascalpersecond = PressureFlowRate.FromPascalsPerSecond(1);
+            Assert.AreEqual(1, PressureFlowRate.FromPascalsPerMinute(pascalpersecond.PascalsPerMinute).PascalsPerSecond, PascalsPerMinuteTolerance);
+            Assert.AreEqual(1, PressureFlowRate.FromPascalsPerSecond(pascalpersecond.PascalsPerSecond).PascalsPerSecond, PascalsPerSecondTolerance);
+        }
+
+        [Test]
+        public void ArithmeticOperators()
+        {
+            PressureFlowRate v = PressureFlowRate.FromPascalsPerSecond(1);
+            Assert.AreEqual(-1, -v.PascalsPerSecond, PascalsPerSecondTolerance);
+            Assert.AreEqual(2, (PressureFlowRate.FromPascalsPerSecond(3)-v).PascalsPerSecond, PascalsPerSecondTolerance);
+            Assert.AreEqual(2, (v + v).PascalsPerSecond, PascalsPerSecondTolerance);
+            Assert.AreEqual(10, (v*10).PascalsPerSecond, PascalsPerSecondTolerance);
+            Assert.AreEqual(10, (10*v).PascalsPerSecond, PascalsPerSecondTolerance);
+            Assert.AreEqual(2, (PressureFlowRate.FromPascalsPerSecond(10)/5).PascalsPerSecond, PascalsPerSecondTolerance);
+            Assert.AreEqual(2, PressureFlowRate.FromPascalsPerSecond(10)/PressureFlowRate.FromPascalsPerSecond(5), PascalsPerSecondTolerance);
+        }
+
+        [Test]
+        public void ComparisonOperators()
+        {
+            PressureFlowRate onePascalPerSecond = PressureFlowRate.FromPascalsPerSecond(1);
+            PressureFlowRate twoPascalsPerSecond = PressureFlowRate.FromPascalsPerSecond(2);
+
+            Assert.True(onePascalPerSecond < twoPascalsPerSecond);
+            Assert.True(onePascalPerSecond <= twoPascalsPerSecond);
+            Assert.True(twoPascalsPerSecond > onePascalPerSecond);
+            Assert.True(twoPascalsPerSecond >= onePascalPerSecond);
+
+            Assert.False(onePascalPerSecond > twoPascalsPerSecond);
+            Assert.False(onePascalPerSecond >= twoPascalsPerSecond);
+            Assert.False(twoPascalsPerSecond < onePascalPerSecond);
+            Assert.False(twoPascalsPerSecond <= onePascalPerSecond);
+        }
+
+        [Test]
+        public void CompareToIsImplemented()
+        {
+            PressureFlowRate pascalpersecond = PressureFlowRate.FromPascalsPerSecond(1);
+            Assert.AreEqual(0, pascalpersecond.CompareTo(pascalpersecond));
+            Assert.Greater(pascalpersecond.CompareTo(PressureFlowRate.Zero), 0);
+            Assert.Less(PressureFlowRate.Zero.CompareTo(pascalpersecond), 0);
+        }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentException))]
+        public void CompareToThrowsOnTypeMismatch()
+        {
+            PressureFlowRate pascalpersecond = PressureFlowRate.FromPascalsPerSecond(1);
+// ReSharper disable once ReturnValueOfPureMethodIsNotUsed
+            pascalpersecond.CompareTo(new object());
+        }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void CompareToThrowsOnNull()
+        { 
+            PressureFlowRate pascalpersecond = PressureFlowRate.FromPascalsPerSecond(1);
+// ReSharper disable once ReturnValueOfPureMethodIsNotUsed
+            pascalpersecond.CompareTo(null);
+        }
+
+
+        [Test]
+        public void EqualityOperators()
+        {
+            PressureFlowRate a = PressureFlowRate.FromPascalsPerSecond(1);
+            PressureFlowRate b = PressureFlowRate.FromPascalsPerSecond(2);
+
+// ReSharper disable EqualExpressionComparison
+            Assert.True(a == a); 
+            Assert.True(a != b);
+
+            Assert.False(a == b);
+            Assert.False(a != a);
+// ReSharper restore EqualExpressionComparison
+        }
+
+        [Test]
+        public void EqualsIsImplemented()
+        {
+            PressureFlowRate v = PressureFlowRate.FromPascalsPerSecond(1);
+            Assert.IsTrue(v.Equals(PressureFlowRate.FromPascalsPerSecond(1)));
+            Assert.IsFalse(v.Equals(PressureFlowRate.Zero));
+        }
+
+        [Test]
+        public void EqualsReturnsFalseOnTypeMismatch()
+        {
+            PressureFlowRate pascalpersecond = PressureFlowRate.FromPascalsPerSecond(1);
+            Assert.IsFalse(pascalpersecond.Equals(new object()));
+        }
+
+        [Test]
+        public void EqualsReturnsFalseOnNull()
+        {
+            PressureFlowRate pascalpersecond = PressureFlowRate.FromPascalsPerSecond(1);
+            Assert.IsFalse(pascalpersecond.Equals(null));
+        }
+    }
+}

--- a/UnitsNet/CustomCode/IQuantity.cs
+++ b/UnitsNet/CustomCode/IQuantity.cs
@@ -1,0 +1,8 @@
+﻿using System;
+
+namespace UnitsNet
+{
+    public interface IQuantity : IComparable
+    {
+    }
+}

--- a/UnitsNet/CustomCode/UnitSystem.cs
+++ b/UnitsNet/CustomCode/UnitSystem.cs
@@ -23,6 +23,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Reflection;
 using JetBrains.Annotations;
 using UnitsNet.I18n;
 

--- a/UnitsNet/GeneratedCode/Enums/PressureFlowRateUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Enums/PressureFlowRateUnit.g.cs
@@ -1,0 +1,31 @@
+﻿// Copyright © 2007 by Initial Force AS.  All rights reserved.
+// https://github.com/InitialForce/UnitsNet
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// ReSharper disable once CheckNamespace
+namespace UnitsNet.Units
+{
+    public enum PressureFlowRateUnit
+    {
+        Undefined = 0,
+        PascalPerMinute,
+        PascalPerSecond,
+    }
+}

--- a/UnitsNet/GeneratedCode/UnitClasses/Acceleration.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/Acceleration.g.cs
@@ -24,6 +24,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -34,7 +35,7 @@ namespace UnitsNet
     ///     Acceleration, in physics, is the rate at which the velocity of an object changes over time. An object's acceleration is the net result of any and all forces acting on the object, as described by Newton's Second Law. The SI unit for acceleration is the Meter per second squared (m/s2). Accelerations are vector quantities (they have magnitude and direction) and add according to the parallelogram law. As a vector, the calculated net force is equal to the product of the object's mass (a scalar quantity) and the acceleration.
     /// </summary>
     // ReSharper disable once PartialTypeWithSinglePart
-    public partial struct Acceleration : IComparable, IComparable<Acceleration>
+    public partial struct Acceleration : IQuantity, IComparable<Acceleration>
     {
         /// <summary>
         ///     Base unit of Acceleration.

--- a/UnitsNet/GeneratedCode/UnitClasses/AmplitudeRatio.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/AmplitudeRatio.g.cs
@@ -24,6 +24,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -34,7 +35,7 @@ namespace UnitsNet
     ///     The strength of a signal expressed in decibels (dB) relative to one volt RMS.
     /// </summary>
     // ReSharper disable once PartialTypeWithSinglePart
-    public partial struct AmplitudeRatio : IComparable, IComparable<AmplitudeRatio>
+    public partial struct AmplitudeRatio : IQuantity, IComparable<AmplitudeRatio>
     {
         /// <summary>
         ///     Base unit of AmplitudeRatio.

--- a/UnitsNet/GeneratedCode/UnitClasses/Angle.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/Angle.g.cs
@@ -24,6 +24,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -34,7 +35,7 @@ namespace UnitsNet
     ///     In geometry, an angle is the figure formed by two rays, called the sides of the angle, sharing a common endpoint, called the vertex of the angle.
     /// </summary>
     // ReSharper disable once PartialTypeWithSinglePart
-    public partial struct Angle : IComparable, IComparable<Angle>
+    public partial struct Angle : IQuantity, IComparable<Angle>
     {
         /// <summary>
         ///     Base unit of Angle.

--- a/UnitsNet/GeneratedCode/UnitClasses/Area.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/Area.g.cs
@@ -24,6 +24,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -34,7 +35,7 @@ namespace UnitsNet
     ///     Area is a quantity that expresses the extent of a two-dimensional surface or shape, or planar lamina, in the plane. Area can be understood as the amount of material with a given thickness that would be necessary to fashion a model of the shape, or the amount of paint necessary to cover the surface with a single coat.[1] It is the two-dimensional analog of the length of a curve (a one-dimensional concept) or the volume of a solid (a three-dimensional concept).
     /// </summary>
     // ReSharper disable once PartialTypeWithSinglePart
-    public partial struct Area : IComparable, IComparable<Area>
+    public partial struct Area : IQuantity, IComparable<Area>
     {
         /// <summary>
         ///     Base unit of Area.

--- a/UnitsNet/GeneratedCode/UnitClasses/Density.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/Density.g.cs
@@ -24,6 +24,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -34,7 +35,7 @@ namespace UnitsNet
     ///     The density, or more precisely, the volumetric mass density, of a substance is its mass per unit volume.
     /// </summary>
     // ReSharper disable once PartialTypeWithSinglePart
-    public partial struct Density : IComparable, IComparable<Density>
+    public partial struct Density : IQuantity, IComparable<Density>
     {
         /// <summary>
         ///     Base unit of Density.

--- a/UnitsNet/GeneratedCode/UnitClasses/Duration.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/Duration.g.cs
@@ -24,6 +24,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -34,7 +35,7 @@ namespace UnitsNet
     ///     Time is a dimension in which events can be ordered from the past through the present into the future, and also the measure of durations of events and the intervals between them.
     /// </summary>
     // ReSharper disable once PartialTypeWithSinglePart
-    public partial struct Duration : IComparable, IComparable<Duration>
+    public partial struct Duration : IQuantity, IComparable<Duration>
     {
         /// <summary>
         ///     Base unit of Duration.

--- a/UnitsNet/GeneratedCode/UnitClasses/ElectricCurrent.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/ElectricCurrent.g.cs
@@ -24,6 +24,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -34,7 +35,7 @@ namespace UnitsNet
     ///     An electric current is a flow of electric charge. In electric circuits this charge is often carried by moving electrons in a wire. It can also be carried by ions in an electrolyte, or by both ions and electrons such as in a plasma.
     /// </summary>
     // ReSharper disable once PartialTypeWithSinglePart
-    public partial struct ElectricCurrent : IComparable, IComparable<ElectricCurrent>
+    public partial struct ElectricCurrent : IQuantity, IComparable<ElectricCurrent>
     {
         /// <summary>
         ///     Base unit of ElectricCurrent.

--- a/UnitsNet/GeneratedCode/UnitClasses/ElectricPotential.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/ElectricPotential.g.cs
@@ -24,6 +24,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -34,7 +35,7 @@ namespace UnitsNet
     ///     In classical electromagnetism, the electric potential (a scalar quantity denoted by Φ, ΦE or V and also called the electric field potential or the electrostatic potential) at a point is the amount of electric potential energy that a unitary point charge would have when located at that point.
     /// </summary>
     // ReSharper disable once PartialTypeWithSinglePart
-    public partial struct ElectricPotential : IComparable, IComparable<ElectricPotential>
+    public partial struct ElectricPotential : IQuantity, IComparable<ElectricPotential>
     {
         /// <summary>
         ///     Base unit of ElectricPotential.

--- a/UnitsNet/GeneratedCode/UnitClasses/ElectricResistance.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/ElectricResistance.g.cs
@@ -24,6 +24,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -34,7 +35,7 @@ namespace UnitsNet
     ///     The electrical resistance of an electrical conductor is the opposition to the passage of an electric current through that conductor.
     /// </summary>
     // ReSharper disable once PartialTypeWithSinglePart
-    public partial struct ElectricResistance : IComparable, IComparable<ElectricResistance>
+    public partial struct ElectricResistance : IQuantity, IComparable<ElectricResistance>
     {
         /// <summary>
         ///     Base unit of ElectricResistance.

--- a/UnitsNet/GeneratedCode/UnitClasses/Energy.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/Energy.g.cs
@@ -24,6 +24,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -34,7 +35,7 @@ namespace UnitsNet
     ///     The joule, symbol J, is a derived unit of energy, work, or amount of heat in the International System of Units. It is equal to the energy transferred (or work done) when applying a force of one newton through a distance of one metre (1 newton metre or N·m), or in passing an electric current of one ampere through a resistance of one ohm for one second
     /// </summary>
     // ReSharper disable once PartialTypeWithSinglePart
-    public partial struct Energy : IComparable, IComparable<Energy>
+    public partial struct Energy : IQuantity, IComparable<Energy>
     {
         /// <summary>
         ///     Base unit of Energy.

--- a/UnitsNet/GeneratedCode/UnitClasses/Flow.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/Flow.g.cs
@@ -24,6 +24,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -34,7 +35,7 @@ namespace UnitsNet
     ///     In physics and engineering, in particular fluid dynamics and hydrometry, the volumetric flow rate, (also known as volume flow rate, rate of fluid flow or volume velocity) is the volume of fluid which passes through a given surface per unit time. The SI unit is m3·s−1 (cubic meters per second). In US Customary Units and British Imperial Units, volumetric flow rate is often expressed as ft3/s (cubic feet per second). It is usually represented by the symbol Q.
     /// </summary>
     // ReSharper disable once PartialTypeWithSinglePart
-    public partial struct Flow : IComparable, IComparable<Flow>
+    public partial struct Flow : IQuantity, IComparable<Flow>
     {
         /// <summary>
         ///     Base unit of Flow.

--- a/UnitsNet/GeneratedCode/UnitClasses/Force.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/Force.g.cs
@@ -24,6 +24,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -34,7 +35,7 @@ namespace UnitsNet
     ///     In physics, a force is any influence that causes an object to undergo a certain change, either concerning its movement, direction, or geometrical construction. In other words, a force can cause an object with mass to change its velocity (which includes to begin moving from a state of rest), i.e., to accelerate, or a flexible object to deform, or both. Force can also be described by intuitive concepts such as a push or a pull. A force has both magnitude and direction, making it a vector quantity. It is measured in the SI unit of newtons and represented by the symbol F.
     /// </summary>
     // ReSharper disable once PartialTypeWithSinglePart
-    public partial struct Force : IComparable, IComparable<Force>
+    public partial struct Force : IQuantity, IComparable<Force>
     {
         /// <summary>
         ///     Base unit of Force.

--- a/UnitsNet/GeneratedCode/UnitClasses/Frequency.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/Frequency.g.cs
@@ -24,6 +24,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -34,7 +35,7 @@ namespace UnitsNet
     ///     The number of occurrences of a repeating event per unit time.
     /// </summary>
     // ReSharper disable once PartialTypeWithSinglePart
-    public partial struct Frequency : IComparable, IComparable<Frequency>
+    public partial struct Frequency : IQuantity, IComparable<Frequency>
     {
         /// <summary>
         ///     Base unit of Frequency.

--- a/UnitsNet/GeneratedCode/UnitClasses/Information.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/Information.g.cs
@@ -24,6 +24,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -34,7 +35,7 @@ namespace UnitsNet
     ///     In computing and telecommunications, a unit of information is the capacity of some standard data storage system or communication channel, used to measure the capacities of other systems and channels. In information theory, units of information are also used to measure the information contents or entropy of random variables.
     /// </summary>
     // ReSharper disable once PartialTypeWithSinglePart
-    public partial struct Information : IComparable, IComparable<Information>
+    public partial struct Information : IQuantity, IComparable<Information>
     {
         /// <summary>
         ///     Base unit of Information.

--- a/UnitsNet/GeneratedCode/UnitClasses/KinematicViscosity.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/KinematicViscosity.g.cs
@@ -24,6 +24,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -34,7 +35,7 @@ namespace UnitsNet
     ///     The viscosity of a fluid is a measure of its resistance to gradual deformation by shear stress or tensile stress.
     /// </summary>
     // ReSharper disable once PartialTypeWithSinglePart
-    public partial struct KinematicViscosity : IComparable, IComparable<KinematicViscosity>
+    public partial struct KinematicViscosity : IQuantity, IComparable<KinematicViscosity>
     {
         /// <summary>
         ///     Base unit of KinematicViscosity.

--- a/UnitsNet/GeneratedCode/UnitClasses/Length.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/Length.g.cs
@@ -24,6 +24,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -34,7 +35,7 @@ namespace UnitsNet
     ///     Many different units of length have been used around the world. The main units in modern use are U.S. customary units in the United States and the Metric system elsewhere. British Imperial units are still used for some purposes in the United Kingdom and some other countries. The metric system is sub-divided into SI and non-SI units.
     /// </summary>
     // ReSharper disable once PartialTypeWithSinglePart
-    public partial struct Length : IComparable, IComparable<Length>
+    public partial struct Length : IQuantity, IComparable<Length>
     {
         /// <summary>
         ///     Base unit of Length.

--- a/UnitsNet/GeneratedCode/UnitClasses/Level.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/Level.g.cs
@@ -24,6 +24,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -34,7 +35,7 @@ namespace UnitsNet
     ///     Level is the logarithm of the ratio of a quantity Q to a reference value of that quantity, Q0, expressed in dimensionless units.
     /// </summary>
     // ReSharper disable once PartialTypeWithSinglePart
-    public partial struct Level : IComparable, IComparable<Level>
+    public partial struct Level : IQuantity, IComparable<Level>
     {
         /// <summary>
         ///     Base unit of Level.

--- a/UnitsNet/GeneratedCode/UnitClasses/Mass.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/Mass.g.cs
@@ -24,6 +24,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -34,7 +35,7 @@ namespace UnitsNet
     ///     In physics, mass (from Greek μᾶζα "barley cake, lump [of dough]") is a property of a physical system or body, giving rise to the phenomena of the body's resistance to being accelerated by a force and the strength of its mutual gravitational attraction with other bodies. Instruments such as mass balances or scales use those phenomena to measure mass. The SI unit of mass is the kilogram (kg).
     /// </summary>
     // ReSharper disable once PartialTypeWithSinglePart
-    public partial struct Mass : IComparable, IComparable<Mass>
+    public partial struct Mass : IQuantity, IComparable<Mass>
     {
         /// <summary>
         ///     Base unit of Mass.

--- a/UnitsNet/GeneratedCode/UnitClasses/Power.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/Power.g.cs
@@ -24,6 +24,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -34,7 +35,7 @@ namespace UnitsNet
     ///     In physics, power is the rate of doing work. It is equivalent to an amount of energy consumed per unit time.
     /// </summary>
     // ReSharper disable once PartialTypeWithSinglePart
-    public partial struct Power : IComparable, IComparable<Power>
+    public partial struct Power : IQuantity, IComparable<Power>
     {
         /// <summary>
         ///     Base unit of Power.

--- a/UnitsNet/GeneratedCode/UnitClasses/PowerRatio.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/PowerRatio.g.cs
@@ -24,6 +24,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -34,7 +35,7 @@ namespace UnitsNet
     ///     The strength of a signal expressed in decibels (dB) relative to one watt.
     /// </summary>
     // ReSharper disable once PartialTypeWithSinglePart
-    public partial struct PowerRatio : IComparable, IComparable<PowerRatio>
+    public partial struct PowerRatio : IQuantity, IComparable<PowerRatio>
     {
         /// <summary>
         ///     Base unit of PowerRatio.

--- a/UnitsNet/GeneratedCode/UnitClasses/Pressure.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/Pressure.g.cs
@@ -24,6 +24,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -34,7 +35,7 @@ namespace UnitsNet
     ///     Pressure (symbol: P or p) is the ratio of force to the area over which that force is distributed. Pressure is force per unit area applied in a direction perpendicular to the surface of an object. Gauge pressure (also spelled gage pressure)[a] is the pressure relative to the local atmospheric or ambient pressure. Pressure is measured in any unit of force divided by any unit of area. The SI unit of pressure is the newton per square metre, which is called the pascal (Pa) after the seventeenth-century philosopher and scientist Blaise Pascal. A pressure of 1 Pa is small; it approximately equals the pressure exerted by a dollar bill resting flat on a table. Everyday pressures are often stated in kilopascals (1 kPa = 1000 Pa).
     /// </summary>
     // ReSharper disable once PartialTypeWithSinglePart
-    public partial struct Pressure : IComparable, IComparable<Pressure>
+    public partial struct Pressure : IQuantity, IComparable<Pressure>
     {
         /// <summary>
         ///     Base unit of Pressure.

--- a/UnitsNet/GeneratedCode/UnitClasses/PressureFlowRate.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/PressureFlowRate.g.cs
@@ -1,0 +1,378 @@
+﻿// Copyright © 2007 by Initial Force AS.  All rights reserved.
+// https://github.com/InitialForce/UnitsNet
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using System.Globalization;
+using System.Text.RegularExpressions;
+using System.Linq;
+using JetBrains.Annotations;
+using UnitsNet.Units;
+
+// ReSharper disable once CheckNamespace
+
+namespace UnitsNet
+{
+    /// <summary>
+    ///     The quantity of pressure flowing per unit of time.
+    /// </summary>
+    // ReSharper disable once PartialTypeWithSinglePart
+    public partial struct PressureFlowRate : IComparable, IComparable<PressureFlowRate>
+    {
+        /// <summary>
+        ///     Base unit of PressureFlowRate.
+        /// </summary>
+        private readonly double _pascalsPerSecond;
+
+        public PressureFlowRate(double pascalspersecond) : this()
+        {
+            _pascalsPerSecond = pascalspersecond;
+        }
+
+        #region Properties
+
+        /// <summary>
+        ///     Get PressureFlowRate in PascalsPerMinute.
+        /// </summary>
+        public double PascalsPerMinute
+        {
+            get { return _pascalsPerSecond*60; }
+        }
+
+        /// <summary>
+        ///     Get PressureFlowRate in PascalsPerSecond.
+        /// </summary>
+        public double PascalsPerSecond
+        {
+            get { return _pascalsPerSecond; }
+        }
+
+        #endregion
+
+        #region Static 
+
+        public static PressureFlowRate Zero
+        {
+            get { return new PressureFlowRate(); }
+        }
+
+        /// <summary>
+        ///     Get PressureFlowRate from PascalsPerMinute.
+        /// </summary>
+        public static PressureFlowRate FromPascalsPerMinute(double pascalsperminute)
+        {
+            return new PressureFlowRate(pascalsperminute/60);
+        }
+
+        /// <summary>
+        ///     Get PressureFlowRate from PascalsPerSecond.
+        /// </summary>
+        public static PressureFlowRate FromPascalsPerSecond(double pascalspersecond)
+        {
+            return new PressureFlowRate(pascalspersecond);
+        }
+
+
+        /// <summary>
+        ///     Dynamically convert from value and unit enum <see cref="PressureFlowRateUnit" /> to <see cref="PressureFlowRate" />.
+        /// </summary>
+        /// <param name="value">Value to convert from.</param>
+        /// <param name="fromUnit">Unit to convert from.</param>
+        /// <returns>PressureFlowRate unit value.</returns>
+        public static PressureFlowRate From(double value, PressureFlowRateUnit fromUnit)
+        {
+            switch (fromUnit)
+            {
+                case PressureFlowRateUnit.PascalPerMinute:
+                    return FromPascalsPerMinute(value);
+                case PressureFlowRateUnit.PascalPerSecond:
+                    return FromPascalsPerSecond(value);
+
+                default:
+                    throw new NotImplementedException("fromUnit: " + fromUnit);
+            }
+        }
+
+        /// <summary>
+        ///     Get unit abbreviation string.
+        /// </summary>
+        /// <param name="unit">Unit to get abbreviation for.</param>
+        /// <param name="culture">Culture to use for localization. Defaults to Thread.CurrentUICulture.</param>
+        /// <returns>Unit abbreviation string.</returns>
+        [UsedImplicitly]
+        public static string GetAbbreviation(PressureFlowRateUnit unit, CultureInfo culture = null)
+        {
+            return UnitSystem.GetCached(culture).GetDefaultAbbreviation(unit);
+        }
+
+        #endregion
+
+        #region Arithmetic Operators
+
+        public static PressureFlowRate operator -(PressureFlowRate right)
+        {
+            return new PressureFlowRate(-right._pascalsPerSecond);
+        }
+
+        public static PressureFlowRate operator +(PressureFlowRate left, PressureFlowRate right)
+        {
+            return new PressureFlowRate(left._pascalsPerSecond + right._pascalsPerSecond);
+        }
+
+        public static PressureFlowRate operator -(PressureFlowRate left, PressureFlowRate right)
+        {
+            return new PressureFlowRate(left._pascalsPerSecond - right._pascalsPerSecond);
+        }
+
+        public static PressureFlowRate operator *(double left, PressureFlowRate right)
+        {
+            return new PressureFlowRate(left*right._pascalsPerSecond);
+        }
+
+        public static PressureFlowRate operator *(PressureFlowRate left, double right)
+        {
+            return new PressureFlowRate(left._pascalsPerSecond*(double)right);
+        }
+
+        public static PressureFlowRate operator /(PressureFlowRate left, double right)
+        {
+            return new PressureFlowRate(left._pascalsPerSecond/(double)right);
+        }
+
+        public static double operator /(PressureFlowRate left, PressureFlowRate right)
+        {
+            return Convert.ToDouble(left._pascalsPerSecond/right._pascalsPerSecond);
+        }
+
+        #endregion
+
+        #region Equality / IComparable
+
+        public int CompareTo(object obj)
+        {
+            if (obj == null) throw new ArgumentNullException("obj");
+            if (!(obj is PressureFlowRate)) throw new ArgumentException("Expected type PressureFlowRate.", "obj");
+            return CompareTo((PressureFlowRate) obj);
+        }
+
+        public int CompareTo(PressureFlowRate other)
+        {
+            return _pascalsPerSecond.CompareTo(other._pascalsPerSecond);
+        }
+
+        public static bool operator <=(PressureFlowRate left, PressureFlowRate right)
+        {
+            return left._pascalsPerSecond <= right._pascalsPerSecond;
+        }
+
+        public static bool operator >=(PressureFlowRate left, PressureFlowRate right)
+        {
+            return left._pascalsPerSecond >= right._pascalsPerSecond;
+        }
+
+        public static bool operator <(PressureFlowRate left, PressureFlowRate right)
+        {
+            return left._pascalsPerSecond < right._pascalsPerSecond;
+        }
+
+        public static bool operator >(PressureFlowRate left, PressureFlowRate right)
+        {
+            return left._pascalsPerSecond > right._pascalsPerSecond;
+        }
+
+        public static bool operator ==(PressureFlowRate left, PressureFlowRate right)
+        {
+            // ReSharper disable once CompareOfFloatsByEqualityOperator
+            return left._pascalsPerSecond == right._pascalsPerSecond;
+        }
+
+        public static bool operator !=(PressureFlowRate left, PressureFlowRate right)
+        {
+            // ReSharper disable once CompareOfFloatsByEqualityOperator
+            return left._pascalsPerSecond != right._pascalsPerSecond;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj == null || GetType() != obj.GetType())
+            {
+                return false;
+            }
+
+            return _pascalsPerSecond.Equals(((PressureFlowRate) obj)._pascalsPerSecond);
+        }
+
+        public override int GetHashCode()
+        {
+            return _pascalsPerSecond.GetHashCode();
+        }
+
+        #endregion
+
+        #region Conversion
+
+        /// <summary>
+        ///     Convert to the unit representation <paramref name="unit" />.
+        /// </summary>
+        /// <returns>Value in new unit if successful, exception otherwise.</returns>
+        /// <exception cref="NotImplementedException">If conversion was not successful.</exception>
+        public double As(PressureFlowRateUnit unit)
+        {
+            switch (unit)
+            {
+                case PressureFlowRateUnit.PascalPerMinute:
+                    return PascalsPerMinute;
+                case PressureFlowRateUnit.PascalPerSecond:
+                    return PascalsPerSecond;
+
+                default:
+                    throw new NotImplementedException("unit: " + unit);
+            }
+        }
+
+        #endregion
+
+        #region Parsing
+
+        /// <summary>
+        ///     Parse a string of the format "&lt;quantity&gt; &lt;unit&gt;".
+        /// </summary>
+        /// <example>
+        ///     Length.Parse("5.5 m", new CultureInfo("en-US"));
+        /// </example>
+        /// <exception cref="ArgumentNullException">The value of 'str' cannot be null. </exception>
+        /// <exception cref="ArgumentException">
+        ///     Expected 2 words. Input string needs to be in the format "&lt;quantity&gt; &lt;unit
+        ///     &gt;".
+        /// </exception>
+        /// <exception cref="UnitsNetException">Error parsing string.</exception>
+        public static PressureFlowRate Parse(string str, IFormatProvider formatProvider = null)
+        {
+            if (str == null) throw new ArgumentNullException("str");
+
+            var numFormat = formatProvider != null ?
+                (NumberFormatInfo) formatProvider.GetFormat(typeof (NumberFormatInfo)) :
+                NumberFormatInfo.CurrentInfo;
+
+            var numRegex = string.Format(@"[\d., {0}{1}]*\d",  // allows digits, dots, commas, and spaces in the quantity (must end in digit)
+                            numFormat.NumberGroupSeparator,    // adds provided (or current) culture's group separator
+                            numFormat.NumberDecimalSeparator); // adds provided (or current) culture's decimal separator
+            var regexString = string.Format("(?<value>[-+]?{0}{1}{2}{3}",
+                            numRegex,              // capture base (integral) Quantity value
+                            @"(?:[eE][-+]?\d+)?)", // capture exponential (if any), end of Quantity capturing
+                            @"\s?",                // ignore whitespace (allows both "1kg", "1 kg")
+                            @"(?<unit>\S+)");      // capture Unit (non-whitespace) input
+
+            var regex = new Regex(regexString);
+            GroupCollection groups = regex.Match(str.Trim()).Groups;
+
+            var valueString = groups["value"].Value;
+            var unitString = groups["unit"].Value;
+
+            if (valueString == "" || unitString == "")
+            {
+                var ex = new ArgumentException(
+                    "Expected valid quantity and unit. Input string needs to be in the format \"<quantity><unit> or <quantity> <unit>\".", "str");
+                ex.Data["input"] = str;
+                ex.Data["formatprovider"] = formatProvider == null ? null : formatProvider.ToString();
+                throw ex;
+            }
+
+            try
+            {
+                PressureFlowRateUnit unit = ParseUnit(unitString, formatProvider);
+                double value = double.Parse(valueString, formatProvider);
+
+                return From(value, unit);
+            }
+            catch (Exception e)
+            {
+                var newEx = new UnitsNetException("Error parsing string.", e);
+                newEx.Data["input"] = str;
+                newEx.Data["formatprovider"] = formatProvider == null ? null : formatProvider.ToString();
+                throw newEx;
+            }
+        }
+
+        /// <summary>
+        ///     Parse a unit string.
+        /// </summary>
+        /// <example>
+        ///     Length.ParseUnit("m", new CultureInfo("en-US"));
+        /// </example>
+        /// <exception cref="ArgumentNullException">The value of 'str' cannot be null. </exception>
+        /// <exception cref="UnitsNetException">Error parsing string.</exception>
+        public static PressureFlowRateUnit ParseUnit(string str, IFormatProvider formatProvider = null)
+        {
+            if (str == null) throw new ArgumentNullException("str");
+            var unitSystem = UnitSystem.GetCached(formatProvider);
+
+            var unit = unitSystem.Parse<PressureFlowRateUnit>(str.Trim());
+
+            if (unit == PressureFlowRateUnit.Undefined)
+            {
+                var newEx = new UnitsNetException("Error parsing string. The unit is not a recognized PressureFlowRateUnit.");
+                newEx.Data["input"] = str;
+                newEx.Data["formatprovider"] = formatProvider == null ? null : formatProvider.ToString();
+                throw newEx;
+            }
+
+            return unit;
+        }
+
+        #endregion
+
+        /// <summary>
+        ///     Get default string representation of value and unit.
+        /// </summary>
+        /// <returns>String representation.</returns>
+        public override string ToString()
+        {
+            return ToString(PressureFlowRateUnit.PascalPerSecond);
+        }
+
+        /// <summary>
+        ///     Get string representation of value and unit.
+        /// </summary>
+        /// <param name="unit">Unit representation to use.</param>
+        /// <param name="culture">Culture to use for localization and number formatting.</param>
+        /// <param name="significantDigitsAfterRadix">The number of significant digits after the radix point.</param>
+        /// <returns>String representation.</returns>
+        [UsedImplicitly]
+        public string ToString(PressureFlowRateUnit unit, CultureInfo culture = null, int significantDigitsAfterRadix = 2)
+        {
+            return ToString(unit, culture, UnitFormatter.GetFormat(As(unit), significantDigitsAfterRadix));
+        }
+
+        /// <summary>
+        ///     Get string representation of value and unit.
+        /// </summary>
+        /// <param name="culture">Culture to use for localization and number formatting.</param>
+        /// <param name="unit">Unit representation to use.</param>
+        /// <param name="format">String format to use. Default:  "{0:0.##} {1} for value and unit abbreviation respectively."</param>
+        /// <param name="args">Arguments for string format. Value and unit are implictly included as arguments 0 and 1.</param>
+        /// <returns>String representation.</returns>
+        [UsedImplicitly]
+        public string ToString(PressureFlowRateUnit unit, CultureInfo culture, string format, params object[] args)
+        {
+            return string.Format(culture, format, UnitFormatter.GetFormatArgs(unit, As(unit), culture, args));
+        }
+    }
+}

--- a/UnitsNet/GeneratedCode/UnitClasses/PressureFlowRate.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/PressureFlowRate.g.cs
@@ -24,6 +24,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -34,7 +35,7 @@ namespace UnitsNet
     ///     The quantity of pressure flowing per unit of time.
     /// </summary>
     // ReSharper disable once PartialTypeWithSinglePart
-    public partial struct PressureFlowRate : IComparable, IComparable<PressureFlowRate>
+    public partial struct PressureFlowRate : IQuantity, IComparable<PressureFlowRate>
     {
         /// <summary>
         ///     Base unit of PressureFlowRate.

--- a/UnitsNet/GeneratedCode/UnitClasses/Ratio.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/Ratio.g.cs
@@ -24,6 +24,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -34,7 +35,7 @@ namespace UnitsNet
     ///     In mathematics, a ratio is a relationship between two numbers of the same kind (e.g., objects, persons, students, spoonfuls, units of whatever identical dimension), usually expressed as "a to b" or a:b, sometimes expressed arithmetically as a dimensionless quotient of the two that explicitly indicates how many times the first number contains the second (not necessarily an integer).
     /// </summary>
     // ReSharper disable once PartialTypeWithSinglePart
-    public partial struct Ratio : IComparable, IComparable<Ratio>
+    public partial struct Ratio : IQuantity, IComparable<Ratio>
     {
         /// <summary>
         ///     Base unit of Ratio.

--- a/UnitsNet/GeneratedCode/UnitClasses/RotationalSpeed.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/RotationalSpeed.g.cs
@@ -24,6 +24,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -34,7 +35,7 @@ namespace UnitsNet
     ///     Rotational speed (sometimes called speed of revolution) is the number of complete rotations, revolutions, cycles, or turns per time unit. Rotational speed is a cyclic frequency, measured in radians per second or in hertz in the SI System by scientists, or in revolutions per minute (rpm or min-1) or revolutions per second in everyday life. The symbol for rotational speed is ω (the Greek lowercase letter "omega").
     /// </summary>
     // ReSharper disable once PartialTypeWithSinglePart
-    public partial struct RotationalSpeed : IComparable, IComparable<RotationalSpeed>
+    public partial struct RotationalSpeed : IQuantity, IComparable<RotationalSpeed>
     {
         /// <summary>
         ///     Base unit of RotationalSpeed.

--- a/UnitsNet/GeneratedCode/UnitClasses/SpecificWeight.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/SpecificWeight.g.cs
@@ -24,6 +24,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -34,7 +35,7 @@ namespace UnitsNet
     ///     The SpecificWeight, or more precisely, the volumetric weight density, of a substance is its weight per unit volume.
     /// </summary>
     // ReSharper disable once PartialTypeWithSinglePart
-    public partial struct SpecificWeight : IComparable, IComparable<SpecificWeight>
+    public partial struct SpecificWeight : IQuantity, IComparable<SpecificWeight>
     {
         /// <summary>
         ///     Base unit of SpecificWeight.

--- a/UnitsNet/GeneratedCode/UnitClasses/Speed.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/Speed.g.cs
@@ -24,6 +24,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -34,7 +35,7 @@ namespace UnitsNet
     ///     In everyday use and in kinematics, the speed of an object is the magnitude of its velocity (the rate of change of its position); it is thus a scalar quantity.[1] The average speed of an object in an interval of time is the distance travelled by the object divided by the duration of the interval;[2] the instantaneous speed is the limit of the average speed as the duration of the time interval approaches zero.
     /// </summary>
     // ReSharper disable once PartialTypeWithSinglePart
-    public partial struct Speed : IComparable, IComparable<Speed>
+    public partial struct Speed : IQuantity, IComparable<Speed>
     {
         /// <summary>
         ///     Base unit of Speed.

--- a/UnitsNet/GeneratedCode/UnitClasses/Temperature.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/Temperature.g.cs
@@ -24,6 +24,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -34,7 +35,7 @@ namespace UnitsNet
     ///     A temperature is a numerical measure of hot or cold. Its measurement is by detection of heat radiation or particle velocity or kinetic energy, or by the bulk behavior of a thermometric material. It may be calibrated in any of various temperature scales, Celsius, Fahrenheit, Kelvin, etc. The fundamental physical definition of temperature is provided by thermodynamics.
     /// </summary>
     // ReSharper disable once PartialTypeWithSinglePart
-    public partial struct Temperature : IComparable, IComparable<Temperature>
+    public partial struct Temperature : IQuantity, IComparable<Temperature>
     {
         /// <summary>
         ///     Base unit of Temperature.

--- a/UnitsNet/GeneratedCode/UnitClasses/Torque.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/Torque.g.cs
@@ -24,6 +24,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -34,7 +35,7 @@ namespace UnitsNet
     ///     Torque, moment or moment of force (see the terminology below), is the tendency of a force to rotate an object about an axis,[1] fulcrum, or pivot. Just as a force is a push or a pull, a torque can be thought of as a twist to an object. Mathematically, torque is defined as the cross product of the lever-arm distance and force, which tends to produce rotation. Loosely speaking, torque is a measure of the turning force on an object such as a bolt or a flywheel. For example, pushing or pulling the handle of a wrench connected to a nut or bolt produces a torque (turning force) that loosens or tightens the nut or bolt.
     /// </summary>
     // ReSharper disable once PartialTypeWithSinglePart
-    public partial struct Torque : IComparable, IComparable<Torque>
+    public partial struct Torque : IQuantity, IComparable<Torque>
     {
         /// <summary>
         ///     Base unit of Torque.

--- a/UnitsNet/GeneratedCode/UnitClasses/Volume.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/Volume.g.cs
@@ -24,6 +24,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -34,7 +35,7 @@ namespace UnitsNet
     ///     Volume is the quantity of three-dimensional space enclosed by some closed boundary, for example, the space that a substance (solid, liquid, gas, or plasma) or shape occupies or contains.[1] Volume is often quantified numerically using the SI derived unit, the cubic metre. The volume of a container is generally understood to be the capacity of the container, i. e. the amount of fluid (gas or liquid) that the container could hold, rather than the amount of space the container itself displaces.
     /// </summary>
     // ReSharper disable once PartialTypeWithSinglePart
-    public partial struct Volume : IComparable, IComparable<Volume>
+    public partial struct Volume : IQuantity, IComparable<Volume>
     {
         /// <summary>
         ///     Base unit of Volume.

--- a/UnitsNet/GeneratedCode/UnitSystem.Default.g.cs
+++ b/UnitsNet/GeneratedCode/UnitSystem.Default.g.cs
@@ -1152,6 +1152,20 @@ namespace UnitsNet
                                 new AbbreviationsForCulture("ru-RU", "торр"),
                             }),
                     }),
+                new UnitLocalization(typeof (PressureFlowRateUnit),
+                    new[]
+                    {
+                        new CulturesForEnumValue((int) PressureFlowRateUnit.PascalPerMinute,
+                            new[]
+                            {
+                                new AbbreviationsForCulture("en-US", "Pa/m"),
+                            }),
+                        new CulturesForEnumValue((int) PressureFlowRateUnit.PascalPerSecond,
+                            new[]
+                            {
+                                new AbbreviationsForCulture("en-US", "Pa/s"),
+                            }),
+                    }),
                 new UnitLocalization(typeof (RatioUnit),
                     new[]
                     {

--- a/UnitsNet/Scripts/Include-GenerateUnitClassSourceCode.ps1
+++ b/UnitsNet/Scripts/Include-GenerateUnitClassSourceCode.ps1
@@ -37,6 +37,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -47,7 +48,7 @@ namespace UnitsNet
     ///     $($unitClass.XmlDoc)
     /// </summary>
     // ReSharper disable once PartialTypeWithSinglePart
-    public partial struct $className : IComparable, IComparable<$className>
+    public partial struct $className : IQuantity, IComparable<$className>
     {
         /// <summary>
         ///     Base unit of $className.

--- a/UnitsNet/Scripts/UnitDefinitions/PressureFlowRate.json
+++ b/UnitsNet/Scripts/UnitDefinitions/PressureFlowRate.json
@@ -1,0 +1,31 @@
+﻿{
+    "Name": "PressureFlowRate",
+    "BaseUnit": "PascalPerSecond",
+    "XmlDoc": "The quantity of pressure flowing per unit of time.",
+    "Units": [
+        {
+            "SingularName": "PascalPerSecond",
+            "PluralName": "PascalsPerSecond",
+            "FromUnitToBaseFunc": "x",
+            "FromBaseToUnitFunc": "x",
+            "Localization": [
+                {
+                    "Culture": "en-US",
+                    "Abbreviations": ["Pa/s"]
+                }
+            ]
+        },
+        {
+            "SingularName": "PascalPerMinute",
+            "PluralName": "PascalsPerMinute",
+            "FromUnitToBaseFunc": "x/60",
+            "FromBaseToUnitFunc": "x*60",
+            "Localization": [
+                {
+                    "Culture": "en-US",
+                    "Abbreviations": ["Pa/m"]
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Introduce a marker to differentiate IComparable (double, string...) from quantities.

That allows to type a little stronger generic APIs working on quantities.