### PR TITLE
Make the units serializable via the use of data contract

### DIFF
--- a/UnitsNet/GeneratedCode/UnitClasses/Acceleration.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/Acceleration.g.cs
@@ -24,6 +24,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
+using System.Runtime.Serialization;
 using JetBrains.Annotations;
 using UnitsNet.Units;
 
@@ -35,11 +36,13 @@ namespace UnitsNet
     ///     Acceleration, in physics, is the rate at which the velocity of an object changes over time. An object's acceleration is the net result of any and all forces acting on the object, as described by Newton's Second Law. The SI unit for acceleration is the Meter per second squared (m/s2). Accelerations are vector quantities (they have magnitude and direction) and add according to the parallelogram law. As a vector, the calculated net force is equal to the product of the object's mass (a scalar quantity) and the acceleration.
     /// </summary>
     // ReSharper disable once PartialTypeWithSinglePart
+	[DataContract]
     public partial struct Acceleration : IComparable, IComparable<Acceleration>
     {
         /// <summary>
         ///     Base unit of Acceleration.
         /// </summary>
+		[DataMember]
         private readonly double _meterPerSecondSquared;
 
         public Acceleration(double meterpersecondsquared) : this()

--- a/UnitsNet/GeneratedCode/UnitClasses/AmplitudeRatio.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/AmplitudeRatio.g.cs
@@ -24,6 +24,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
+using System.Runtime.Serialization;
 using JetBrains.Annotations;
 using UnitsNet.Units;
 
@@ -35,11 +36,13 @@ namespace UnitsNet
     ///     The strength of a signal expressed in decibels (dB) relative to one volt RMS.
     /// </summary>
     // ReSharper disable once PartialTypeWithSinglePart
+	[DataContract]
     public partial struct AmplitudeRatio : IComparable, IComparable<AmplitudeRatio>
     {
         /// <summary>
         ///     Base unit of AmplitudeRatio.
         /// </summary>
+		[DataMember]
         private readonly double _decibelVolts;
 
         public AmplitudeRatio(double decibelvolts) : this()

--- a/UnitsNet/GeneratedCode/UnitClasses/Angle.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/Angle.g.cs
@@ -24,6 +24,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
+using System.Runtime.Serialization;
 using JetBrains.Annotations;
 using UnitsNet.Units;
 
@@ -35,11 +36,13 @@ namespace UnitsNet
     ///     In geometry, an angle is the figure formed by two rays, called the sides of the angle, sharing a common endpoint, called the vertex of the angle.
     /// </summary>
     // ReSharper disable once PartialTypeWithSinglePart
+	[DataContract]
     public partial struct Angle : IComparable, IComparable<Angle>
     {
         /// <summary>
         ///     Base unit of Angle.
         /// </summary>
+		[DataMember]
         private readonly double _degrees;
 
         public Angle(double degrees) : this()

--- a/UnitsNet/GeneratedCode/UnitClasses/Area.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/Area.g.cs
@@ -24,6 +24,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
+using System.Runtime.Serialization;
 using JetBrains.Annotations;
 using UnitsNet.Units;
 
@@ -35,11 +36,13 @@ namespace UnitsNet
     ///     Area is a quantity that expresses the extent of a two-dimensional surface or shape, or planar lamina, in the plane. Area can be understood as the amount of material with a given thickness that would be necessary to fashion a model of the shape, or the amount of paint necessary to cover the surface with a single coat.[1] It is the two-dimensional analog of the length of a curve (a one-dimensional concept) or the volume of a solid (a three-dimensional concept).
     /// </summary>
     // ReSharper disable once PartialTypeWithSinglePart
+	[DataContract]
     public partial struct Area : IComparable, IComparable<Area>
     {
         /// <summary>
         ///     Base unit of Area.
         /// </summary>
+		[DataMember]
         private readonly double _squareMeters;
 
         public Area(double squaremeters) : this()

--- a/UnitsNet/GeneratedCode/UnitClasses/Density.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/Density.g.cs
@@ -24,6 +24,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
+using System.Runtime.Serialization;
 using JetBrains.Annotations;
 using UnitsNet.Units;
 
@@ -35,11 +36,13 @@ namespace UnitsNet
     ///     The density, or more precisely, the volumetric mass density, of a substance is its mass per unit volume.
     /// </summary>
     // ReSharper disable once PartialTypeWithSinglePart
+	[DataContract]
     public partial struct Density : IComparable, IComparable<Density>
     {
         /// <summary>
         ///     Base unit of Density.
         /// </summary>
+		[DataMember]
         private readonly double _kilogramsPerCubicMeter;
 
         public Density(double kilogramspercubicmeter) : this()

--- a/UnitsNet/GeneratedCode/UnitClasses/Duration.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/Duration.g.cs
@@ -24,6 +24,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
+using System.Runtime.Serialization;
 using JetBrains.Annotations;
 using UnitsNet.Units;
 
@@ -35,11 +36,13 @@ namespace UnitsNet
     ///     Time is a dimension in which events can be ordered from the past through the present into the future, and also the measure of durations of events and the intervals between them.
     /// </summary>
     // ReSharper disable once PartialTypeWithSinglePart
+	[DataContract]
     public partial struct Duration : IComparable, IComparable<Duration>
     {
         /// <summary>
         ///     Base unit of Duration.
         /// </summary>
+		[DataMember]
         private readonly double _seconds;
 
         public Duration(double seconds) : this()

--- a/UnitsNet/GeneratedCode/UnitClasses/ElectricCurrent.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/ElectricCurrent.g.cs
@@ -24,6 +24,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
+using System.Runtime.Serialization;
 using JetBrains.Annotations;
 using UnitsNet.Units;
 
@@ -35,11 +36,13 @@ namespace UnitsNet
     ///     An electric current is a flow of electric charge. In electric circuits this charge is often carried by moving electrons in a wire. It can also be carried by ions in an electrolyte, or by both ions and electrons such as in a plasma.
     /// </summary>
     // ReSharper disable once PartialTypeWithSinglePart
+	[DataContract]
     public partial struct ElectricCurrent : IComparable, IComparable<ElectricCurrent>
     {
         /// <summary>
         ///     Base unit of ElectricCurrent.
         /// </summary>
+		[DataMember]
         private readonly double _amperes;
 
         public ElectricCurrent(double amperes) : this()

--- a/UnitsNet/GeneratedCode/UnitClasses/ElectricPotential.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/ElectricPotential.g.cs
@@ -24,6 +24,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
+using System.Runtime.Serialization;
 using JetBrains.Annotations;
 using UnitsNet.Units;
 
@@ -35,11 +36,13 @@ namespace UnitsNet
     ///     In classical electromagnetism, the electric potential (a scalar quantity denoted by Φ, ΦE or V and also called the electric field potential or the electrostatic potential) at a point is the amount of electric potential energy that a unitary point charge would have when located at that point.
     /// </summary>
     // ReSharper disable once PartialTypeWithSinglePart
+	[DataContract]
     public partial struct ElectricPotential : IComparable, IComparable<ElectricPotential>
     {
         /// <summary>
         ///     Base unit of ElectricPotential.
         /// </summary>
+		[DataMember]
         private readonly double _volts;
 
         public ElectricPotential(double volts) : this()

--- a/UnitsNet/GeneratedCode/UnitClasses/ElectricResistance.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/ElectricResistance.g.cs
@@ -24,6 +24,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
+using System.Runtime.Serialization;
 using JetBrains.Annotations;
 using UnitsNet.Units;
 
@@ -35,11 +36,13 @@ namespace UnitsNet
     ///     The electrical resistance of an electrical conductor is the opposition to the passage of an electric current through that conductor.
     /// </summary>
     // ReSharper disable once PartialTypeWithSinglePart
+	[DataContract]
     public partial struct ElectricResistance : IComparable, IComparable<ElectricResistance>
     {
         /// <summary>
         ///     Base unit of ElectricResistance.
         /// </summary>
+		[DataMember]
         private readonly double _ohms;
 
         public ElectricResistance(double ohms) : this()

--- a/UnitsNet/GeneratedCode/UnitClasses/Energy.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/Energy.g.cs
@@ -24,6 +24,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
+using System.Runtime.Serialization;
 using JetBrains.Annotations;
 using UnitsNet.Units;
 
@@ -35,11 +36,13 @@ namespace UnitsNet
     ///     The joule, symbol J, is a derived unit of energy, work, or amount of heat in the International System of Units. It is equal to the energy transferred (or work done) when applying a force of one newton through a distance of one metre (1 newton metre or N·m), or in passing an electric current of one ampere through a resistance of one ohm for one second. Many other units of energy are included. Please do not confuse this definition of the calorie with the one colloquially used by the food industry, the large calorie, which is equivalent to 1 kcal. Thermochemical definition of the calorie is used. For BTU, the IT definition is used.
     /// </summary>
     // ReSharper disable once PartialTypeWithSinglePart
+	[DataContract]
     public partial struct Energy : IComparable, IComparable<Energy>
     {
         /// <summary>
         ///     Base unit of Energy.
         /// </summary>
+		[DataMember]
         private readonly double _joules;
 
         public Energy(double joules) : this()

--- a/UnitsNet/GeneratedCode/UnitClasses/Flow.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/Flow.g.cs
@@ -24,6 +24,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
+using System.Runtime.Serialization;
 using JetBrains.Annotations;
 using UnitsNet.Units;
 
@@ -35,11 +36,13 @@ namespace UnitsNet
     ///     In physics and engineering, in particular fluid dynamics and hydrometry, the volumetric flow rate, (also known as volume flow rate, rate of fluid flow or volume velocity) is the volume of fluid which passes through a given surface per unit time. The SI unit is m3·s−1 (cubic meters per second). In US Customary Units and British Imperial Units, volumetric flow rate is often expressed as ft3/s (cubic feet per second). It is usually represented by the symbol Q.
     /// </summary>
     // ReSharper disable once PartialTypeWithSinglePart
+	[DataContract]
     public partial struct Flow : IComparable, IComparable<Flow>
     {
         /// <summary>
         ///     Base unit of Flow.
         /// </summary>
+		[DataMember]
         private readonly double _cubicMetersPerSecond;
 
         public Flow(double cubicmeterspersecond) : this()

--- a/UnitsNet/GeneratedCode/UnitClasses/Force.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/Force.g.cs
@@ -24,6 +24,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
+using System.Runtime.Serialization;
 using JetBrains.Annotations;
 using UnitsNet.Units;
 
@@ -35,11 +36,13 @@ namespace UnitsNet
     ///     In physics, a force is any influence that causes an object to undergo a certain change, either concerning its movement, direction, or geometrical construction. In other words, a force can cause an object with mass to change its velocity (which includes to begin moving from a state of rest), i.e., to accelerate, or a flexible object to deform, or both. Force can also be described by intuitive concepts such as a push or a pull. A force has both magnitude and direction, making it a vector quantity. It is measured in the SI unit of newtons and represented by the symbol F.
     /// </summary>
     // ReSharper disable once PartialTypeWithSinglePart
+	[DataContract]
     public partial struct Force : IComparable, IComparable<Force>
     {
         /// <summary>
         ///     Base unit of Force.
         /// </summary>
+		[DataMember]
         private readonly double _newtons;
 
         public Force(double newtons) : this()

--- a/UnitsNet/GeneratedCode/UnitClasses/Frequency.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/Frequency.g.cs
@@ -24,6 +24,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
+using System.Runtime.Serialization;
 using JetBrains.Annotations;
 using UnitsNet.Units;
 
@@ -35,11 +36,13 @@ namespace UnitsNet
     ///     The number of occurrences of a repeating event per unit time.
     /// </summary>
     // ReSharper disable once PartialTypeWithSinglePart
+	[DataContract]
     public partial struct Frequency : IComparable, IComparable<Frequency>
     {
         /// <summary>
         ///     Base unit of Frequency.
         /// </summary>
+		[DataMember]
         private readonly double _hertz;
 
         public Frequency(double hertz) : this()

--- a/UnitsNet/GeneratedCode/UnitClasses/Information.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/Information.g.cs
@@ -24,6 +24,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
+using System.Runtime.Serialization;
 using JetBrains.Annotations;
 using UnitsNet.Units;
 
@@ -35,11 +36,13 @@ namespace UnitsNet
     ///     In computing and telecommunications, a unit of information is the capacity of some standard data storage system or communication channel, used to measure the capacities of other systems and channels. In information theory, units of information are also used to measure the information contents or entropy of random variables.
     /// </summary>
     // ReSharper disable once PartialTypeWithSinglePart
+	[DataContract]
     public partial struct Information : IComparable, IComparable<Information>
     {
         /// <summary>
         ///     Base unit of Information.
         /// </summary>
+		[DataMember]
         private readonly decimal _bits;
 
         public Information(decimal bits) : this()

--- a/UnitsNet/GeneratedCode/UnitClasses/KinematicViscosity.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/KinematicViscosity.g.cs
@@ -24,6 +24,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
+using System.Runtime.Serialization;
 using JetBrains.Annotations;
 using UnitsNet.Units;
 
@@ -35,11 +36,13 @@ namespace UnitsNet
     ///     The viscosity of a fluid is a measure of its resistance to gradual deformation by shear stress or tensile stress.
     /// </summary>
     // ReSharper disable once PartialTypeWithSinglePart
+	[DataContract]
     public partial struct KinematicViscosity : IComparable, IComparable<KinematicViscosity>
     {
         /// <summary>
         ///     Base unit of KinematicViscosity.
         /// </summary>
+		[DataMember]
         private readonly double _squareMetersPerSecond;
 
         public KinematicViscosity(double squaremeterspersecond) : this()

--- a/UnitsNet/GeneratedCode/UnitClasses/Length.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/Length.g.cs
@@ -24,6 +24,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
+using System.Runtime.Serialization;
 using JetBrains.Annotations;
 using UnitsNet.Units;
 
@@ -35,11 +36,13 @@ namespace UnitsNet
     ///     Many different units of length have been used around the world. The main units in modern use are U.S. customary units in the United States and the Metric system elsewhere. British Imperial units are still used for some purposes in the United Kingdom and some other countries. The metric system is sub-divided into SI and non-SI units.
     /// </summary>
     // ReSharper disable once PartialTypeWithSinglePart
+	[DataContract]
     public partial struct Length : IComparable, IComparable<Length>
     {
         /// <summary>
         ///     Base unit of Length.
         /// </summary>
+		[DataMember]
         private readonly double _meters;
 
         public Length(double meters) : this()

--- a/UnitsNet/GeneratedCode/UnitClasses/Level.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/Level.g.cs
@@ -24,6 +24,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
+using System.Runtime.Serialization;
 using JetBrains.Annotations;
 using UnitsNet.Units;
 
@@ -35,11 +36,13 @@ namespace UnitsNet
     ///     Level is the logarithm of the ratio of a quantity Q to a reference value of that quantity, Q0, expressed in dimensionless units.
     /// </summary>
     // ReSharper disable once PartialTypeWithSinglePart
+	[DataContract]
     public partial struct Level : IComparable, IComparable<Level>
     {
         /// <summary>
         ///     Base unit of Level.
         /// </summary>
+		[DataMember]
         private readonly double _decibels;
 
         public Level(double decibels) : this()

--- a/UnitsNet/GeneratedCode/UnitClasses/Mass.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/Mass.g.cs
@@ -24,6 +24,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
+using System.Runtime.Serialization;
 using JetBrains.Annotations;
 using UnitsNet.Units;
 
@@ -35,11 +36,13 @@ namespace UnitsNet
     ///     In physics, mass (from Greek μᾶζα "barley cake, lump [of dough]") is a property of a physical system or body, giving rise to the phenomena of the body's resistance to being accelerated by a force and the strength of its mutual gravitational attraction with other bodies. Instruments such as mass balances or scales use those phenomena to measure mass. The SI unit of mass is the kilogram (kg).
     /// </summary>
     // ReSharper disable once PartialTypeWithSinglePart
+	[DataContract]
     public partial struct Mass : IComparable, IComparable<Mass>
     {
         /// <summary>
         ///     Base unit of Mass.
         /// </summary>
+		[DataMember]
         private readonly double _kilograms;
 
         public Mass(double kilograms) : this()

--- a/UnitsNet/GeneratedCode/UnitClasses/Power.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/Power.g.cs
@@ -24,6 +24,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
+using System.Runtime.Serialization;
 using JetBrains.Annotations;
 using UnitsNet.Units;
 
@@ -35,11 +36,13 @@ namespace UnitsNet
     ///     In physics, power is the rate of doing work. It is equivalent to an amount of energy consumed per unit time.
     /// </summary>
     // ReSharper disable once PartialTypeWithSinglePart
+	[DataContract]
     public partial struct Power : IComparable, IComparable<Power>
     {
         /// <summary>
         ///     Base unit of Power.
         /// </summary>
+		[DataMember]
         private readonly decimal _watts;
 
         public Power(decimal watts) : this()

--- a/UnitsNet/GeneratedCode/UnitClasses/PowerRatio.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/PowerRatio.g.cs
@@ -24,6 +24,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
+using System.Runtime.Serialization;
 using JetBrains.Annotations;
 using UnitsNet.Units;
 
@@ -35,11 +36,13 @@ namespace UnitsNet
     ///     The strength of a signal expressed in decibels (dB) relative to one watt.
     /// </summary>
     // ReSharper disable once PartialTypeWithSinglePart
+	[DataContract]
     public partial struct PowerRatio : IComparable, IComparable<PowerRatio>
     {
         /// <summary>
         ///     Base unit of PowerRatio.
         /// </summary>
+		[DataMember]
         private readonly double _decibelWatts;
 
         public PowerRatio(double decibelwatts) : this()

--- a/UnitsNet/GeneratedCode/UnitClasses/Pressure.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/Pressure.g.cs
@@ -24,6 +24,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
+using System.Runtime.Serialization;
 using JetBrains.Annotations;
 using UnitsNet.Units;
 
@@ -35,11 +36,13 @@ namespace UnitsNet
     ///     Pressure (symbol: P or p) is the ratio of force to the area over which that force is distributed. Pressure is force per unit area applied in a direction perpendicular to the surface of an object. Gauge pressure (also spelled gage pressure)[a] is the pressure relative to the local atmospheric or ambient pressure. Pressure is measured in any unit of force divided by any unit of area. The SI unit of pressure is the newton per square metre, which is called the pascal (Pa) after the seventeenth-century philosopher and scientist Blaise Pascal. A pressure of 1 Pa is small; it approximately equals the pressure exerted by a dollar bill resting flat on a table. Everyday pressures are often stated in kilopascals (1 kPa = 1000 Pa).
     /// </summary>
     // ReSharper disable once PartialTypeWithSinglePart
+	[DataContract]
     public partial struct Pressure : IComparable, IComparable<Pressure>
     {
         /// <summary>
         ///     Base unit of Pressure.
         /// </summary>
+		[DataMember]
         private readonly double _pascals;
 
         public Pressure(double pascals) : this()

--- a/UnitsNet/GeneratedCode/UnitClasses/Ratio.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/Ratio.g.cs
@@ -24,6 +24,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
+using System.Runtime.Serialization;
 using JetBrains.Annotations;
 using UnitsNet.Units;
 
@@ -35,11 +36,13 @@ namespace UnitsNet
     ///     In mathematics, a ratio is a relationship between two numbers of the same kind (e.g., objects, persons, students, spoonfuls, units of whatever identical dimension), usually expressed as "a to b" or a:b, sometimes expressed arithmetically as a dimensionless quotient of the two that explicitly indicates how many times the first number contains the second (not necessarily an integer).
     /// </summary>
     // ReSharper disable once PartialTypeWithSinglePart
+	[DataContract]
     public partial struct Ratio : IComparable, IComparable<Ratio>
     {
         /// <summary>
         ///     Base unit of Ratio.
         /// </summary>
+		[DataMember]
         private readonly double _decimalFractions;
 
         public Ratio(double decimalfractions) : this()

--- a/UnitsNet/GeneratedCode/UnitClasses/RotationalSpeed.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/RotationalSpeed.g.cs
@@ -24,6 +24,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
+using System.Runtime.Serialization;
 using JetBrains.Annotations;
 using UnitsNet.Units;
 
@@ -35,11 +36,13 @@ namespace UnitsNet
     ///     Rotational speed (sometimes called speed of revolution) is the number of complete rotations, revolutions, cycles, or turns per time unit. Rotational speed is a cyclic frequency, measured in radians per second or in hertz in the SI System by scientists, or in revolutions per minute (rpm or min-1) or revolutions per second in everyday life. The symbol for rotational speed is ω (the Greek lowercase letter "omega").
     /// </summary>
     // ReSharper disable once PartialTypeWithSinglePart
+	[DataContract]
     public partial struct RotationalSpeed : IComparable, IComparable<RotationalSpeed>
     {
         /// <summary>
         ///     Base unit of RotationalSpeed.
         /// </summary>
+		[DataMember]
         private readonly double _revolutionsPerSecond;
 
         public RotationalSpeed(double revolutionspersecond) : this()

--- a/UnitsNet/GeneratedCode/UnitClasses/SpecificWeight.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/SpecificWeight.g.cs
@@ -24,6 +24,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
+using System.Runtime.Serialization;
 using JetBrains.Annotations;
 using UnitsNet.Units;
 
@@ -35,11 +36,13 @@ namespace UnitsNet
     ///     The SpecificWeight, or more precisely, the volumetric weight density, of a substance is its weight per unit volume.
     /// </summary>
     // ReSharper disable once PartialTypeWithSinglePart
+	[DataContract]
     public partial struct SpecificWeight : IComparable, IComparable<SpecificWeight>
     {
         /// <summary>
         ///     Base unit of SpecificWeight.
         /// </summary>
+		[DataMember]
         private readonly double _newtonsPerCubicMeter;
 
         public SpecificWeight(double newtonspercubicmeter) : this()

--- a/UnitsNet/GeneratedCode/UnitClasses/Speed.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/Speed.g.cs
@@ -24,6 +24,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
+using System.Runtime.Serialization;
 using JetBrains.Annotations;
 using UnitsNet.Units;
 
@@ -35,11 +36,13 @@ namespace UnitsNet
     ///     In everyday use and in kinematics, the speed of an object is the magnitude of its velocity (the rate of change of its position); it is thus a scalar quantity.[1] The average speed of an object in an interval of time is the distance travelled by the object divided by the duration of the interval;[2] the instantaneous speed is the limit of the average speed as the duration of the time interval approaches zero.
     /// </summary>
     // ReSharper disable once PartialTypeWithSinglePart
+	[DataContract]
     public partial struct Speed : IComparable, IComparable<Speed>
     {
         /// <summary>
         ///     Base unit of Speed.
         /// </summary>
+		[DataMember]
         private readonly double _metersPerSecond;
 
         public Speed(double meterspersecond) : this()

--- a/UnitsNet/GeneratedCode/UnitClasses/Temperature.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/Temperature.g.cs
@@ -24,6 +24,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
+using System.Runtime.Serialization;
 using JetBrains.Annotations;
 using UnitsNet.Units;
 
@@ -35,11 +36,13 @@ namespace UnitsNet
     ///     A temperature is a numerical measure of hot or cold. Its measurement is by detection of heat radiation or particle velocity or kinetic energy, or by the bulk behavior of a thermometric material. It may be calibrated in any of various temperature scales, Celsius, Fahrenheit, Kelvin, etc. The fundamental physical definition of temperature is provided by thermodynamics.
     /// </summary>
     // ReSharper disable once PartialTypeWithSinglePart
+	[DataContract]
     public partial struct Temperature : IComparable, IComparable<Temperature>
     {
         /// <summary>
         ///     Base unit of Temperature.
         /// </summary>
+		[DataMember]
         private readonly double _kelvins;
 
         public Temperature(double kelvins) : this()

--- a/UnitsNet/GeneratedCode/UnitClasses/Torque.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/Torque.g.cs
@@ -24,6 +24,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
+using System.Runtime.Serialization;
 using JetBrains.Annotations;
 using UnitsNet.Units;
 
@@ -35,11 +36,13 @@ namespace UnitsNet
     ///     Torque, moment or moment of force (see the terminology below), is the tendency of a force to rotate an object about an axis,[1] fulcrum, or pivot. Just as a force is a push or a pull, a torque can be thought of as a twist to an object. Mathematically, torque is defined as the cross product of the lever-arm distance and force, which tends to produce rotation. Loosely speaking, torque is a measure of the turning force on an object such as a bolt or a flywheel. For example, pushing or pulling the handle of a wrench connected to a nut or bolt produces a torque (turning force) that loosens or tightens the nut or bolt.
     /// </summary>
     // ReSharper disable once PartialTypeWithSinglePart
+	[DataContract]
     public partial struct Torque : IComparable, IComparable<Torque>
     {
         /// <summary>
         ///     Base unit of Torque.
         /// </summary>
+		[DataMember]
         private readonly double _newtonMeters;
 
         public Torque(double newtonmeters) : this()

--- a/UnitsNet/GeneratedCode/UnitClasses/Volume.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/Volume.g.cs
@@ -24,6 +24,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
+using System.Runtime.Serialization;
 using JetBrains.Annotations;
 using UnitsNet.Units;
 
@@ -35,11 +36,13 @@ namespace UnitsNet
     ///     Volume is the quantity of three-dimensional space enclosed by some closed boundary, for example, the space that a substance (solid, liquid, gas, or plasma) or shape occupies or contains.[1] Volume is often quantified numerically using the SI derived unit, the cubic metre. The volume of a container is generally understood to be the capacity of the container, i. e. the amount of fluid (gas or liquid) that the container could hold, rather than the amount of space the container itself displaces.
     /// </summary>
     // ReSharper disable once PartialTypeWithSinglePart
+	[DataContract]
     public partial struct Volume : IComparable, IComparable<Volume>
     {
         /// <summary>
         ///     Base unit of Volume.
         /// </summary>
+		[DataMember]
         private readonly double _cubicMeters;
 
         public Volume(double cubicmeters) : this()

--- a/UnitsNet/Scripts/Include-GenerateUnitClassSourceCode.ps1
+++ b/UnitsNet/Scripts/Include-GenerateUnitClassSourceCode.ps1
@@ -37,6 +37,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Linq;
+using System.Runtime.Serialization;
 using JetBrains.Annotations;
 using UnitsNet.Units;
 
@@ -48,11 +49,13 @@ namespace UnitsNet
     ///     $($unitClass.XmlDoc)
     /// </summary>
     // ReSharper disable once PartialTypeWithSinglePart
+	[DataContract]
     public partial struct $className : IComparable, IComparable<$className>
     {
         /// <summary>
         ///     Base unit of $className.
         /// </summary>
+		[DataMember]
         private readonly $baseType $baseUnitFieldName;
 
         public $className($baseType $baseUnitPluralNameLower) : this()

--- a/UnitsNet/UnitsNet.Net35.csproj
+++ b/UnitsNet/UnitsNet.Net35.csproj
@@ -37,6 +37,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Data" />

--- a/UnitsNet/UnitsNet.Net451.csproj
+++ b/UnitsNet/UnitsNet.Net451.csproj
@@ -36,6 +36,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />


### PR DESCRIPTION
Datacontract is part of dotnet portable, so it gives the ability to serialize in xml unitsnet objects.

It may be the answer to json serialization because datacontract offers a datacontractjsonserializer class.

Allthough I have tested it locally, the actual unit tests do not cover this use case.
We would need to create integration unit tests for that purpose.
