### PR TITLE
Feature/additional overloading

### DIFF
--- a/UnitsNet.Tests/InterUnitConversionTests.cs
+++ b/UnitsNet.Tests/InterUnitConversionTests.cs
@@ -44,7 +44,7 @@ namespace UnitsNet.Tests
         }
 
         [Test]
-        public void LengthAndTimeStampToSpeed()
+        public void LengthAndTimepanToSpeed()
         {
             Length length = Length.FromMeters(10);
             Speed speed = length / TimeSpan.FromSeconds(1);

--- a/UnitsNet.Tests/InterUnitConversionTests.cs
+++ b/UnitsNet.Tests/InterUnitConversionTests.cs
@@ -20,6 +20,7 @@
 // THE SOFTWARE.
 
 using NUnit.Framework;
+using System;
 
 namespace UnitsNet.Tests
 {
@@ -40,6 +41,14 @@ namespace UnitsNet.Tests
             Mass mass = Mass.FromKilograms(1);
             Force force = Force.FromKilogramsForce(mass.Kilograms);
             Assert.AreEqual(mass.Kilograms, force.KilogramsForce);
+        }
+
+        [Test]
+        public void LengthAndTimeStampToSpeed()
+        {
+            Length length = Length.FromMeters(10);
+            Speed speed = length / TimeSpan.FromSeconds(1);
+            Assert.AreEqual(10.0, speed.MetersPerSecond);
         }
     }
 }

--- a/UnitsNet.Tests/InterUnitConversionTests.cs
+++ b/UnitsNet.Tests/InterUnitConversionTests.cs
@@ -44,11 +44,39 @@ namespace UnitsNet.Tests
         }
 
         [Test]
-        public void LengthAndTimepanToSpeed()
+        public void LengthAndTimeSpanToSpeed()
         {
             Length length = Length.FromMeters(10);
             Speed speed = length / TimeSpan.FromSeconds(1);
             Assert.AreEqual(10.0, speed.MetersPerSecond);
+        }
+
+        [Test]
+        public void LengthAndLengthToArea()
+        {
+            Length length1 = Length.FromMeters(10);
+            Length length2 = Length.FromMeters(20);
+            Area area = length1 * length2;
+            Assert.AreEqual(200.0, area.SquareMeters);
+        }
+
+        [Test]
+        public void LengthAndAreaToVolume()
+        {
+            Length length = Length.FromMeters(10);
+            Area area = Area.FromSquareMeters(20);
+            Volume volume = length * area;
+            Assert.AreEqual(200.0, volume.CubicMeters);
+        }
+
+
+        [Test]
+        public void LengthAndForceToEnergy()
+        {
+            Length length = Length.FromMeters(10);
+            Force force = Force.FromNewtons(20);
+            Energy energy = length * force;
+            Assert.AreEqual(200.0, energy.Joules);
         }
     }
 }

--- a/UnitsNet/GeneratedCode/UnitClasses/Length.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/Length.g.cs
@@ -366,6 +366,10 @@ namespace UnitsNet
         }
 
         #endregion
+        public static Speed operator / (Length left, TimeSpan right)
+		{
+			return Speed.FromMetersPerSecond(left.Meters/right.TotalSeconds) ;
+		}
 
         #region Equality / IComparable
 

--- a/UnitsNet/GeneratedCode/UnitClasses/Length.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/Length.g.cs
@@ -368,7 +368,19 @@ namespace UnitsNet
         #endregion
         public static Speed operator / (Length left, TimeSpan right)
 		{
-			return Speed.FromMetersPerSecond(left.Meters/right.TotalSeconds) ;
+			return Speed.FromMetersPerSecond(left.Meters / right.TotalSeconds);
+		}
+        public static Area operator * (Length left, Length right)
+		{
+			return Area.FromSquareMeters(left.Meters * right.Meters);
+		}
+        public static Volume operator * (Length left, Area right)
+		{
+			return Volume.FromCubicMeters(left.Meters * right.SquareMeters);
+		}
+        public static Energy operator * (Length left, Force right)
+		{
+			return Energy.FromJoules(left.Meters * right.Newtons);
 		}
 
         #region Equality / IComparable

--- a/UnitsNet/Scripts/Include-GenerateUnitClassSourceCode.ps1
+++ b/UnitsNet/Scripts/Include-GenerateUnitClassSourceCode.ps1
@@ -181,17 +181,9 @@ namespace UnitsNet
         }
 
         #endregion
-
-<<<<<<< HEAD
 "@; }
-			
-		foreach ($operatorOverload in $operatorOverloads) {
-=======
-		#region Operator overloads to other units
-"@; }
-	
 		 foreach ($operatorOverload in $operatorOverloads) {
->>>>>>> 28f46c434f89d5b3672439ca1f76efe237b201d5
+
 				$returnUnit = $operatorOverload.ReturnUnit;
 				$operator = $operatorOverload.Operator;
 				$otherUnit = $operatorOverload.OtherUnit;
@@ -203,11 +195,6 @@ namespace UnitsNet
 		}
 "@; }
 		@"
-<<<<<<< HEAD
-=======
-
-		#endregion
->>>>>>> 28f46c434f89d5b3672439ca1f76efe237b201d5
 
         #region Equality / IComparable
 

--- a/UnitsNet/Scripts/Include-GenerateUnitClassSourceCode.ps1
+++ b/UnitsNet/Scripts/Include-GenerateUnitClassSourceCode.ps1
@@ -182,10 +182,16 @@ namespace UnitsNet
 
         #endregion
 
+<<<<<<< HEAD
+"@; }
+			
+		foreach ($operatorOverload in $operatorOverloads) {
+=======
 		#region Operator overloads to other units
 "@; }
 	
 		 foreach ($operatorOverload in $operatorOverloads) {
+>>>>>>> 28f46c434f89d5b3672439ca1f76efe237b201d5
 				$returnUnit = $operatorOverload.ReturnUnit;
 				$operator = $operatorOverload.Operator;
 				$otherUnit = $operatorOverload.OtherUnit;
@@ -197,8 +203,11 @@ namespace UnitsNet
 		}
 "@; }
 		@"
+<<<<<<< HEAD
+=======
 
 		#endregion
+>>>>>>> 28f46c434f89d5b3672439ca1f76efe237b201d5
 
         #region Equality / IComparable
 

--- a/UnitsNet/Scripts/Include-GenerateUnitClassSourceCode.ps1
+++ b/UnitsNet/Scripts/Include-GenerateUnitClassSourceCode.ps1
@@ -186,12 +186,12 @@ namespace UnitsNet
 
 				$returnUnit = $operatorOverload.ReturnUnit;
 				$operator = $operatorOverload.Operator;
-				$otherUnit = $operatorOverload.OtherUnit;
-				$conversionCode = $operatorOverload.ConversionCode
+				$returnUnitBasePluralName = $operatorOverload.ReturnUnitBasePluralName;
+				$otherUnitBasePluralName = $operatorOverload.OtherUnitBasePluralName;
 			 @"
-        public static $returnUnit operator $operator ($className left, $otherUnit right)
+        public static $returnUnit operator $operator ($className left, $($operatorOverload.OtherUnit) right)
 		{
-			return $conversionCode ;
+			return $returnUnit.From$returnUnitBasePluralName(left.$baseUnitPluralName $operator right.$otherUnitBasePluralName);
 		}
 "@; }
 		@"

--- a/UnitsNet/Scripts/Include-GenerateUnitClassSourceCode.ps1
+++ b/UnitsNet/Scripts/Include-GenerateUnitClassSourceCode.ps1
@@ -9,6 +9,7 @@ function GenerateUnitClassSourceCode($unitClass)
     $baseUnitPluralNameLower = $baseUnitPluralName.ToLowerInvariant()
     $unitEnumName = "$className" + "Unit";
     $baseUnitFieldName = "_"+[Char]::ToLowerInvariant($baseUnitPluralName[0]) + $baseUnitPluralName.Substring(1);
+	$operatorOverloads = $unitClass.OperatorOverloads;
 
 @"
 // Copyright © 2007 by Initial Force AS.  All rights reserved.
@@ -180,7 +181,24 @@ namespace UnitsNet
         }
 
         #endregion
-"@; }@"
+
+		#region Operator overloads to other units
+"@; }
+	
+		 foreach ($operatorOverload in $operatorOverloads) {
+				$returnUnit = $operatorOverload.ReturnUnit;
+				$operator = $operatorOverload.Operator;
+				$otherUnit = $operatorOverload.OtherUnit;
+				$conversionCode = $operatorOverload.ConversionCode
+			 @"
+        public static $returnUnit operator $operator ($className left, $otherUnit right)
+		{
+			return $conversionCode ;
+		}
+"@; }
+		@"
+
+		#endregion
 
         #region Equality / IComparable
 

--- a/UnitsNet/Scripts/UnitDefinitions/Length.json
+++ b/UnitsNet/Scripts/UnitDefinitions/Length.json
@@ -1,121 +1,129 @@
 ﻿{
-    "Name": "Length",
-    "BaseUnit": "Meter",
-    "XmlDoc": "Many different units of length have been used around the world. The main units in modern use are U.S. customary units in the United States and the Metric system elsewhere. British Imperial units are still used for some purposes in the United Kingdom and some other countries. The metric system is sub-divided into SI and non-SI units.",
-    "Units": [
+  "Name": "Length",
+  "BaseUnit": "Meter",
+  "XmlDoc": "Many different units of length have been used around the world. The main units in modern use are U.S. customary units in the United States and the Metric system elsewhere. British Imperial units are still used for some purposes in the United Kingdom and some other countries. The metric system is sub-divided into SI and non-SI units.",
+  "Units": [
+    {
+      "SingularName": "Meter",
+      "PluralName": "Meters",
+      "FromUnitToBaseFunc": "x",
+      "FromBaseToUnitFunc": "x",
+      "Prefixes": [ "Nano", "Micro", "Milli", "Centi", "Deci", "Kilo" ],
+      "Localization": [
         {
-            "SingularName": "Meter",
-            "PluralName": "Meters",
-            "FromUnitToBaseFunc": "x",
-            "FromBaseToUnitFunc": "x",
-            "Prefixes": ["Nano","Micro","Milli","Centi","Deci","Kilo"],
-            "Localization": [
-                {
-                    "Culture": "en-US",
-                    "Abbreviations": ["m"]
-                },
-                {
-                    "Culture": "ru-RU",
-                    "Abbreviations": ["м"],
-                    "AbbreviationsWithPrefixes": ["нм","мкм","мм","см","дм","км"]
-                }
-            ]
+          "Culture": "en-US",
+          "Abbreviations": [ "m" ]
         },
         {
-            "SingularName": "Mile",
-            "PluralName": "Miles",
-            "FromUnitToBaseFunc": "x*1609.34",
-            "FromBaseToUnitFunc": "x/1609.34",
-            "Localization": [
-                {
-                    "Culture": "en-US",
-                    "Abbreviations": ["mi"]
-                },
-                {
-                    "Culture": "ru-RU",
-                    "Abbreviations": ["миля"]
-                }
-            ]
-        },
-        {
-            "SingularName": "Yard",
-            "PluralName": "Yards",
-            "FromUnitToBaseFunc": "x*0.9144",
-            "FromBaseToUnitFunc": "x/0.9144",
-            "Localization": [
-                {
-                    "Culture": "en-US",
-                    "Abbreviations": ["yd"]
-                },
-                {
-                    "Culture": "ru-RU",
-                    "Abbreviations": ["ярд"]
-                }
-            ]
-        },
-        {
-            "SingularName": "Foot",
-            "PluralName": "Feet",
-            "FromUnitToBaseFunc": "x*0.3048",
-            "FromBaseToUnitFunc": "x/0.3048",
-            "Localization": [
-                {
-                    "Culture": "en-US",
-                    "Abbreviations": ["ft","\\\'"]
-                },
-                {
-                    "Culture": "ru-RU",
-                    "Abbreviations": ["фут"]
-                }
-            ]
-        },
-        {
-            "SingularName": "Inch",
-            "PluralName": "Inches",
-            "FromUnitToBaseFunc": "x*2.54e-2",
-            "FromBaseToUnitFunc": "x/2.54e-2",
-            "Localization": [
-                {
-                    "Culture": "en-US",
-                    "Abbreviations": ["in","\\\""]
-                },
-                {
-                    "Culture": "ru-RU",
-                    "Abbreviations": ["дюйм"]
-                }
-            ]
-        },
-        {
-            "SingularName": "Mil",
-            "PluralName": "Mils",
-            "FromUnitToBaseFunc": "x*2.54e-5",
-            "FromBaseToUnitFunc": "x/2.54e-5",
-            "Localization": [
-                {
-                    "Culture": "en-US",
-                    "Abbreviations": ["mil"]
-                },
-                {
-                    "Culture": "ru-RU",
-                    "Abbreviations": ["мил"]
-                }
-            ]
-        },
-        {
-            "SingularName": "Microinch",
-            "PluralName": "Microinches",
-            "FromUnitToBaseFunc": "x*2.54e-8",
-            "FromBaseToUnitFunc": "x/2.54e-8",
-            "Localization": [
-                {
-                    "Culture": "en-US",
-                    "Abbreviations": ["μin"]
-                },
-                {
-                    "Culture": "ru-RU",
-                    "Abbreviations": ["микродюйм"]
-                }
-            ]
+          "Culture": "ru-RU",
+          "Abbreviations": [ "м" ],
+          "AbbreviationsWithPrefixes": [ "нм", "мкм", "мм", "см", "дм", "км" ]
         }
-    ]
+      ]
+    },
+    {
+      "SingularName": "Mile",
+      "PluralName": "Miles",
+      "FromUnitToBaseFunc": "x*1609.34",
+      "FromBaseToUnitFunc": "x/1609.34",
+      "Localization": [
+        {
+          "Culture": "en-US",
+          "Abbreviations": [ "mi" ]
+        },
+        {
+          "Culture": "ru-RU",
+          "Abbreviations": [ "миля" ]
+        }
+      ]
+    },
+    {
+      "SingularName": "Yard",
+      "PluralName": "Yards",
+      "FromUnitToBaseFunc": "x*0.9144",
+      "FromBaseToUnitFunc": "x/0.9144",
+      "Localization": [
+        {
+          "Culture": "en-US",
+          "Abbreviations": [ "yd" ]
+        },
+        {
+          "Culture": "ru-RU",
+          "Abbreviations": [ "ярд" ]
+        }
+      ]
+    },
+    {
+      "SingularName": "Foot",
+      "PluralName": "Feet",
+      "FromUnitToBaseFunc": "x*0.3048",
+      "FromBaseToUnitFunc": "x/0.3048",
+      "Localization": [
+        {
+          "Culture": "en-US",
+          "Abbreviations": [ "ft", "\\\'" ]
+        },
+        {
+          "Culture": "ru-RU",
+          "Abbreviations": [ "фут" ]
+        }
+      ]
+    },
+    {
+      "SingularName": "Inch",
+      "PluralName": "Inches",
+      "FromUnitToBaseFunc": "x*2.54e-2",
+      "FromBaseToUnitFunc": "x/2.54e-2",
+      "Localization": [
+        {
+          "Culture": "en-US",
+          "Abbreviations": [ "in", "\\\"" ]
+        },
+        {
+          "Culture": "ru-RU",
+          "Abbreviations": [ "дюйм" ]
+        }
+      ]
+    },
+    {
+      "SingularName": "Mil",
+      "PluralName": "Mils",
+      "FromUnitToBaseFunc": "x*2.54e-5",
+      "FromBaseToUnitFunc": "x/2.54e-5",
+      "Localization": [
+        {
+          "Culture": "en-US",
+          "Abbreviations": [ "mil" ]
+        },
+        {
+          "Culture": "ru-RU",
+          "Abbreviations": [ "мил" ]
+        }
+      ]
+    },
+    {
+      "SingularName": "Microinch",
+      "PluralName": "Microinches",
+      "FromUnitToBaseFunc": "x*2.54e-8",
+      "FromBaseToUnitFunc": "x/2.54e-8",
+      "Localization": [
+        {
+          "Culture": "en-US",
+          "Abbreviations": [ "μin" ]
+        },
+        {
+          "Culture": "ru-RU",
+          "Abbreviations": [ "микродюйм" ]
+        }
+      ]
+    }
+  ]
+  "OperatorOverloads": [
+    {
+      "Operator": "/",
+      "OtherUnit": "TimeSpan",
+      "ReturnUnit":  "Speed",
+      "ConversionCode":  "Speed.FromMetersPerSecond(left.Meters/right.TotalSeconds)"
+    }
+  ]
 }

--- a/UnitsNet/Scripts/UnitDefinitions/Length.json
+++ b/UnitsNet/Scripts/UnitDefinitions/Length.json
@@ -122,8 +122,30 @@
     {
       "Operator": "/",
       "OtherUnit": "TimeSpan",
-      "ReturnUnit":  "Speed",
-      "ConversionCode":  "Speed.FromMetersPerSecond(left.Meters/right.TotalSeconds)"
+      "ReturnUnit": "Speed",
+      "ReturnUnitBasePluralName": "MetersPerSecond",
+      "OtherUnitBasePluralName": "TotalSeconds"
+    },
+    {
+      "Operator": "*",
+      "OtherUnit": "Length",
+      "ReturnUnit": "Area",
+      "ReturnUnitBasePluralName": "SquareMeters",
+      "OtherUnitBasePluralName": "Meters"
+    },
+    {
+      "Operator": "*",
+      "OtherUnit": "Area",
+      "ReturnUnit": "Volume",
+      "ReturnUnitBasePluralName": "CubicMeters",
+      "OtherUnitBasePluralName": "SquareMeters"
+    },
+    {
+      "Operator": "*",
+      "OtherUnit": "Force",
+      "ReturnUnit": "Energy",
+      "ReturnUnitBasePluralName": "Joules",
+      "OtherUnitBasePluralName": "Newtons"
     }
   ]
 }

--- a/UnitsNet/Scripts/UnitDefinitions/Length.json
+++ b/UnitsNet/Scripts/UnitDefinitions/Length.json
@@ -117,7 +117,7 @@
         }
       ]
     }
-  ]
+  ],
   "OperatorOverloads": [
     {
       "Operator": "/",


### PR DESCRIPTION
As discussed in #89:

I finally got code at a stage were its worth sharing. I've added code generation for overloads. This is what it looks like for Length (sorry about the re-formatting of the Length.json file, VS did that automatically).
´´´
"OperatorOverloads": [
    {
      "Operator": "/",
      "OtherUnit": "TimeSpan",
      "ReturnUnit": "Speed",
      "ReturnUnitBasePluralName": "MetersPerSecond",
      "OtherUnitBasePluralName": "TotalSeconds"
    },
´´´
It would be nice if it could automatically create the corresponding overload in Speed (I think all the needed information is there), but since this is the first time I'm working with PowerShell scripts it would be faster for me to do this manually for the 32 quantities...

At the moment I've only added the operator overloading for Length. If you like it I can do the same for the rest of the units.

I've added some tests in InterUnitConversionTests.cs to show the end result but I can't think of good auto-generated test. All tests I can think of would just test the generation code and not the actual conversion. If you have a good idea I'm happy to do the work.
