### PR TITLE
Add metric, us legal and us customary cups to volume

### DIFF
--- a/UnitsNet.Tests/CustomCode/VolumeTests.cs
+++ b/UnitsNet.Tests/CustomCode/VolumeTests.cs
@@ -66,8 +66,14 @@ namespace UnitsNet.Tests.CustomCode
         protected override double TeaspoonsTolerance => 1E-3;
 
         protected override double UsGallonsInOneCubicMeter => 264.17217;
-
+        
         protected override double UsOuncesInOneCubicMeter => 33814.02270;
+
+        protected override double MetricCupsInOneCubicMeter => 4000;
+
+        protected override double UsCustomaryCupsInOneCubicMeter => 4226.75283773;
+
+        protected override double UsLegalCupsInOneCubicMeter => 4166.666666667;
 
         [Test]
         public void VolumeDividedByAreaEqualsLength()

--- a/UnitsNet.Tests/GeneratedCode/VolumeTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/VolumeTestsBase.g.cs
@@ -51,10 +51,13 @@ namespace UnitsNet.Tests
         protected abstract double ImperialGallonsInOneCubicMeter { get; }
         protected abstract double ImperialOuncesInOneCubicMeter { get; }
         protected abstract double LitersInOneCubicMeter { get; }
+        protected abstract double MetricCupsInOneCubicMeter { get; }
         protected abstract double MillilitersInOneCubicMeter { get; }
         protected abstract double TablespoonsInOneCubicMeter { get; }
         protected abstract double TeaspoonsInOneCubicMeter { get; }
+        protected abstract double UsCustomaryCupsInOneCubicMeter { get; }
         protected abstract double UsGallonsInOneCubicMeter { get; }
+        protected abstract double UsLegalCupsInOneCubicMeter { get; }
         protected abstract double UsOuncesInOneCubicMeter { get; }
 
 // ReSharper disable VirtualMemberNeverOverriden.Global
@@ -73,10 +76,13 @@ namespace UnitsNet.Tests
         protected virtual double ImperialGallonsTolerance { get { return 1e-5; } }
         protected virtual double ImperialOuncesTolerance { get { return 1e-5; } }
         protected virtual double LitersTolerance { get { return 1e-5; } }
+        protected virtual double MetricCupsTolerance { get { return 1e-5; } }
         protected virtual double MillilitersTolerance { get { return 1e-5; } }
         protected virtual double TablespoonsTolerance { get { return 1e-5; } }
         protected virtual double TeaspoonsTolerance { get { return 1e-5; } }
+        protected virtual double UsCustomaryCupsTolerance { get { return 1e-5; } }
         protected virtual double UsGallonsTolerance { get { return 1e-5; } }
+        protected virtual double UsLegalCupsTolerance { get { return 1e-5; } }
         protected virtual double UsOuncesTolerance { get { return 1e-5; } }
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
@@ -99,10 +105,13 @@ namespace UnitsNet.Tests
             Assert.AreEqual(ImperialGallonsInOneCubicMeter, cubicmeter.ImperialGallons, ImperialGallonsTolerance);
             Assert.AreEqual(ImperialOuncesInOneCubicMeter, cubicmeter.ImperialOunces, ImperialOuncesTolerance);
             Assert.AreEqual(LitersInOneCubicMeter, cubicmeter.Liters, LitersTolerance);
+            Assert.AreEqual(MetricCupsInOneCubicMeter, cubicmeter.MetricCups, MetricCupsTolerance);
             Assert.AreEqual(MillilitersInOneCubicMeter, cubicmeter.Milliliters, MillilitersTolerance);
             Assert.AreEqual(TablespoonsInOneCubicMeter, cubicmeter.Tablespoons, TablespoonsTolerance);
             Assert.AreEqual(TeaspoonsInOneCubicMeter, cubicmeter.Teaspoons, TeaspoonsTolerance);
+            Assert.AreEqual(UsCustomaryCupsInOneCubicMeter, cubicmeter.UsCustomaryCups, UsCustomaryCupsTolerance);
             Assert.AreEqual(UsGallonsInOneCubicMeter, cubicmeter.UsGallons, UsGallonsTolerance);
+            Assert.AreEqual(UsLegalCupsInOneCubicMeter, cubicmeter.UsLegalCups, UsLegalCupsTolerance);
             Assert.AreEqual(UsOuncesInOneCubicMeter, cubicmeter.UsOunces, UsOuncesTolerance);
         }
 
@@ -124,10 +133,13 @@ namespace UnitsNet.Tests
             Assert.AreEqual(1, Volume.From(1, VolumeUnit.ImperialGallon).ImperialGallons, ImperialGallonsTolerance);
             Assert.AreEqual(1, Volume.From(1, VolumeUnit.ImperialOunce).ImperialOunces, ImperialOuncesTolerance);
             Assert.AreEqual(1, Volume.From(1, VolumeUnit.Liter).Liters, LitersTolerance);
+            Assert.AreEqual(1, Volume.From(1, VolumeUnit.MetricCup).MetricCups, MetricCupsTolerance);
             Assert.AreEqual(1, Volume.From(1, VolumeUnit.Milliliter).Milliliters, MillilitersTolerance);
             Assert.AreEqual(1, Volume.From(1, VolumeUnit.Tablespoon).Tablespoons, TablespoonsTolerance);
             Assert.AreEqual(1, Volume.From(1, VolumeUnit.Teaspoon).Teaspoons, TeaspoonsTolerance);
+            Assert.AreEqual(1, Volume.From(1, VolumeUnit.UsCustomaryCup).UsCustomaryCups, UsCustomaryCupsTolerance);
             Assert.AreEqual(1, Volume.From(1, VolumeUnit.UsGallon).UsGallons, UsGallonsTolerance);
+            Assert.AreEqual(1, Volume.From(1, VolumeUnit.UsLegalCup).UsLegalCups, UsLegalCupsTolerance);
             Assert.AreEqual(1, Volume.From(1, VolumeUnit.UsOunce).UsOunces, UsOuncesTolerance);
         }
 
@@ -150,10 +162,13 @@ namespace UnitsNet.Tests
             Assert.AreEqual(ImperialGallonsInOneCubicMeter, cubicmeter.As(VolumeUnit.ImperialGallon), ImperialGallonsTolerance);
             Assert.AreEqual(ImperialOuncesInOneCubicMeter, cubicmeter.As(VolumeUnit.ImperialOunce), ImperialOuncesTolerance);
             Assert.AreEqual(LitersInOneCubicMeter, cubicmeter.As(VolumeUnit.Liter), LitersTolerance);
+            Assert.AreEqual(MetricCupsInOneCubicMeter, cubicmeter.As(VolumeUnit.MetricCup), MetricCupsTolerance);
             Assert.AreEqual(MillilitersInOneCubicMeter, cubicmeter.As(VolumeUnit.Milliliter), MillilitersTolerance);
             Assert.AreEqual(TablespoonsInOneCubicMeter, cubicmeter.As(VolumeUnit.Tablespoon), TablespoonsTolerance);
             Assert.AreEqual(TeaspoonsInOneCubicMeter, cubicmeter.As(VolumeUnit.Teaspoon), TeaspoonsTolerance);
+            Assert.AreEqual(UsCustomaryCupsInOneCubicMeter, cubicmeter.As(VolumeUnit.UsCustomaryCup), UsCustomaryCupsTolerance);
             Assert.AreEqual(UsGallonsInOneCubicMeter, cubicmeter.As(VolumeUnit.UsGallon), UsGallonsTolerance);
+            Assert.AreEqual(UsLegalCupsInOneCubicMeter, cubicmeter.As(VolumeUnit.UsLegalCup), UsLegalCupsTolerance);
             Assert.AreEqual(UsOuncesInOneCubicMeter, cubicmeter.As(VolumeUnit.UsOunce), UsOuncesTolerance);
         }
 
@@ -176,10 +191,13 @@ namespace UnitsNet.Tests
             Assert.AreEqual(1, Volume.FromImperialGallons(cubicmeter.ImperialGallons).CubicMeters, ImperialGallonsTolerance);
             Assert.AreEqual(1, Volume.FromImperialOunces(cubicmeter.ImperialOunces).CubicMeters, ImperialOuncesTolerance);
             Assert.AreEqual(1, Volume.FromLiters(cubicmeter.Liters).CubicMeters, LitersTolerance);
+            Assert.AreEqual(1, Volume.FromMetricCups(cubicmeter.MetricCups).CubicMeters, MetricCupsTolerance);
             Assert.AreEqual(1, Volume.FromMilliliters(cubicmeter.Milliliters).CubicMeters, MillilitersTolerance);
             Assert.AreEqual(1, Volume.FromTablespoons(cubicmeter.Tablespoons).CubicMeters, TablespoonsTolerance);
             Assert.AreEqual(1, Volume.FromTeaspoons(cubicmeter.Teaspoons).CubicMeters, TeaspoonsTolerance);
+            Assert.AreEqual(1, Volume.FromUsCustomaryCups(cubicmeter.UsCustomaryCups).CubicMeters, UsCustomaryCupsTolerance);
             Assert.AreEqual(1, Volume.FromUsGallons(cubicmeter.UsGallons).CubicMeters, UsGallonsTolerance);
+            Assert.AreEqual(1, Volume.FromUsLegalCups(cubicmeter.UsLegalCups).CubicMeters, UsLegalCupsTolerance);
             Assert.AreEqual(1, Volume.FromUsOunces(cubicmeter.UsOunces).CubicMeters, UsOuncesTolerance);
         }
 

--- a/UnitsNet/GeneratedCode/Enums/VolumeUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Enums/VolumeUnit.g.cs
@@ -40,10 +40,13 @@ namespace UnitsNet.Units
         ImperialGallon,
         ImperialOunce,
         Liter,
+        MetricCup,
         Milliliter,
         Tablespoon,
         Teaspoon,
+        UsCustomaryCup,
         UsGallon,
+        UsLegalCup,
         UsOunce,
     }
 }

--- a/UnitsNet/GeneratedCode/UnitClasses/Volume.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/Volume.g.cs
@@ -175,6 +175,14 @@ namespace UnitsNet
         }
 
         /// <summary>
+        ///     Get Volume in MetricCups.
+        /// </summary>
+        public double MetricCups
+        {
+            get { return _cubicMeters/0.00025; }
+        }
+
+        /// <summary>
         ///     Get Volume in Milliliters.
         /// </summary>
         public double Milliliters
@@ -199,11 +207,27 @@ namespace UnitsNet
         }
 
         /// <summary>
+        ///     Get Volume in UsCustomaryCups.
+        /// </summary>
+        public double UsCustomaryCups
+        {
+            get { return _cubicMeters/0.0002365882365; }
+        }
+
+        /// <summary>
         ///     Get Volume in UsGallons.
         /// </summary>
         public double UsGallons
         {
             get { return _cubicMeters/0.00378541; }
+        }
+
+        /// <summary>
+        ///     Get Volume in UsLegalCups.
+        /// </summary>
+        public double UsLegalCups
+        {
+            get { return _cubicMeters/0.00024; }
         }
 
         /// <summary>
@@ -344,6 +368,14 @@ namespace UnitsNet
         }
 
         /// <summary>
+        ///     Get Volume from MetricCups.
+        /// </summary>
+        public static Volume FromMetricCups(double metriccups)
+        {
+            return new Volume(metriccups*0.00025);
+        }
+
+        /// <summary>
         ///     Get Volume from Milliliters.
         /// </summary>
         public static Volume FromMilliliters(double milliliters)
@@ -368,11 +400,27 @@ namespace UnitsNet
         }
 
         /// <summary>
+        ///     Get Volume from UsCustomaryCups.
+        /// </summary>
+        public static Volume FromUsCustomaryCups(double uscustomarycups)
+        {
+            return new Volume(uscustomarycups*0.0002365882365);
+        }
+
+        /// <summary>
         ///     Get Volume from UsGallons.
         /// </summary>
         public static Volume FromUsGallons(double usgallons)
         {
             return new Volume(usgallons*0.00378541);
+        }
+
+        /// <summary>
+        ///     Get Volume from UsLegalCups.
+        /// </summary>
+        public static Volume FromUsLegalCups(double uslegalcups)
+        {
+            return new Volume(uslegalcups*0.00024);
         }
 
         /// <summary>
@@ -424,14 +472,20 @@ namespace UnitsNet
                     return FromImperialOunces(value);
                 case VolumeUnit.Liter:
                     return FromLiters(value);
+                case VolumeUnit.MetricCup:
+                    return FromMetricCups(value);
                 case VolumeUnit.Milliliter:
                     return FromMilliliters(value);
                 case VolumeUnit.Tablespoon:
                     return FromTablespoons(value);
                 case VolumeUnit.Teaspoon:
                     return FromTeaspoons(value);
+                case VolumeUnit.UsCustomaryCup:
+                    return FromUsCustomaryCups(value);
                 case VolumeUnit.UsGallon:
                     return FromUsGallons(value);
+                case VolumeUnit.UsLegalCup:
+                    return FromUsLegalCups(value);
                 case VolumeUnit.UsOunce:
                     return FromUsOunces(value);
 
@@ -597,14 +651,20 @@ namespace UnitsNet
                     return ImperialOunces;
                 case VolumeUnit.Liter:
                     return Liters;
+                case VolumeUnit.MetricCup:
+                    return MetricCups;
                 case VolumeUnit.Milliliter:
                     return Milliliters;
                 case VolumeUnit.Tablespoon:
                     return Tablespoons;
                 case VolumeUnit.Teaspoon:
                     return Teaspoons;
+                case VolumeUnit.UsCustomaryCup:
+                    return UsCustomaryCups;
                 case VolumeUnit.UsGallon:
                     return UsGallons;
+                case VolumeUnit.UsLegalCup:
+                    return UsLegalCups;
                 case VolumeUnit.UsOunce:
                     return UsOunces;
 

--- a/UnitsNet/GeneratedCode/UnitSystem.Default.g.cs
+++ b/UnitsNet/GeneratedCode/UnitSystem.Default.g.cs
@@ -1959,6 +1959,11 @@ namespace UnitsNet
                                 new AbbreviationsForCulture("en-US", "l"),
                                 new AbbreviationsForCulture("ru-RU", "л"),
                             }),
+                        new CulturesForEnumValue((int) VolumeUnit.MetricCup,
+                            new[]
+                            {
+                                new AbbreviationsForCulture("en-US", ""),
+                            }),
                         new CulturesForEnumValue((int) VolumeUnit.Milliliter,
                             new[]
                             {
@@ -1979,11 +1984,21 @@ namespace UnitsNet
                                 new AbbreviationsForCulture("ru-RU", "чайная ложка"),
                                 new AbbreviationsForCulture("nb-NO", "ts", "ts."),
                             }),
+                        new CulturesForEnumValue((int) VolumeUnit.UsCustomaryCup,
+                            new[]
+                            {
+                                new AbbreviationsForCulture("en-US", ""),
+                            }),
                         new CulturesForEnumValue((int) VolumeUnit.UsGallon,
                             new[]
                             {
                                 new AbbreviationsForCulture("en-US", "gal (U.S.)"),
                                 new AbbreviationsForCulture("ru-RU", "Американский галлон"),
+                            }),
+                        new CulturesForEnumValue((int) VolumeUnit.UsLegalCup,
+                            new[]
+                            {
+                                new AbbreviationsForCulture("en-US", ""),
                             }),
                         new CulturesForEnumValue((int) VolumeUnit.UsOunce,
                             new[]

--- a/UnitsNet/Scripts/UnitDefinitions/Volume.json
+++ b/UnitsNet/Scripts/UnitDefinitions/Volume.json
@@ -268,6 +268,42 @@
                     "Abbreviations": ["ts", "ts."]
                 }
             ]
+        },
+        {
+            "SingularName": "MetricCup",
+            "PluralName": "MetricCups",
+            "FromUnitToBaseFunc": "x*0.00025",
+            "FromBaseToUnitFunc": "x/0.00025",
+            "Localization": [
+                {
+                    "Culture": "en-US",
+                    "Abbreviations": []
+                }
+            ]
+        },
+        {
+            "SingularName": "UsCustomaryCup",
+            "PluralName": "UsCustomaryCups",
+            "FromUnitToBaseFunc": "x*0.0002365882365",
+            "FromBaseToUnitFunc": "x/0.0002365882365",
+            "Localization": [
+                {
+                    "Culture": "en-US",
+                    "Abbreviations": []
+                }
+            ]
+        },
+        {
+            "SingularName": "UsLegalCup",
+            "PluralName": "UsLegalCups",
+            "FromUnitToBaseFunc": "x*0.00024",
+            "FromBaseToUnitFunc": "x/0.00024",
+            "Localization": [
+                {
+                    "Culture": "en-US",
+                    "Abbreviations": []
+                }
+            ]
         }
     ]
 }


### PR DESCRIPTION
As per #130 adds the three cup units to volume.

I didn't add an abbreviation for the three as it is too ambiguous IMHO.
I tried "metric cup" but that broke `Volume.Parse` which didn't like the two word combination