### PR TITLE
Added overload for length divided by speed

### DIFF
--- a/UnitsNet.Tests/CustomCode/LengthTests.cs
+++ b/UnitsNet.Tests/CustomCode/LengthTests.cs
@@ -91,6 +91,13 @@ namespace UnitsNet.Tests.CustomCode
         }
 
         [Test]
+        public void LengthDividedBySpeedEqualsDuration()
+        {
+            Duration duration = Length.FromMeters(20) / Speed.FromMetersPerSecond(2);
+            Assert.AreEqual(Duration.FromSeconds(10), duration);
+        }
+
+        [Test]
         public void ToStringReturnsCorrectNumberAndUnitWithDefaultUnitWhichIsMeter()
         {
             Length.ToStringDefaultUnit = LengthUnit.Meter;

--- a/UnitsNet/CustomCode/UnitClasses/Length.extra.cs
+++ b/UnitsNet/CustomCode/UnitClasses/Length.extra.cs
@@ -68,6 +68,11 @@ namespace UnitsNet
             return Speed.FromMetersPerSecond(length.Meters/duration.Seconds);
         }
 
+        public static Duration operator /(Length length, Speed speed)
+        {
+            return Duration.FromSeconds(length.Meters / speed.MetersPerSecond);
+        }
+
         public static Area operator *(Length length1, Length length2)
         {
             return Area.FromSquareMeters(length1.Meters*length2.Meters);


### PR DESCRIPTION
I just discovered that I manged to miss the overload for `Duration=Length/Speed`