### PR TITLE
Added overloads and conversion to TimeSpan for Duration

### DIFF
--- a/UnitsNet.Tests/CustomCode/DurationTests.cs
+++ b/UnitsNet.Tests/CustomCode/DurationTests.cs
@@ -19,6 +19,9 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+using NUnit.Framework;
+using System;
+
 namespace UnitsNet.Tests.CustomCode
 {
     public class DurationTests : DurationTestsBase
@@ -42,5 +45,71 @@ namespace UnitsNet.Tests.CustomCode
         protected override double WeeksInOneSecond => 1.6534e-6;
 
         protected override double YearsInOneSecond => 3.1689e-8;
+
+        [Test]
+        public static void ToTimeSpanShouldThrowExceptionOnValuesLargerThanTimeSpanMax()
+        {
+            Duration duration = Duration.FromSeconds(TimeSpan.MaxValue.TotalSeconds + 1);
+            Assert.Throws<ArgumentOutOfRangeException>(() => duration.ToTimeSpan());
+        }
+
+        [Test]
+        public static void ToTimeSpanShouldThrowExceptionOnValuesSmallerThanTimeSpanMin()
+        {
+            Duration duration = Duration.FromSeconds(TimeSpan.MinValue.TotalSeconds - 1);
+            Assert.Throws<ArgumentOutOfRangeException>(() => duration.ToTimeSpan());
+        }
+
+        [Test]
+        public static void ToTimeSpanShouldNotThrowExceptionOnValuesSlightlyLargerThanTimeSpanMin()
+        {
+            Duration duration = Duration.FromSeconds(TimeSpan.MinValue.TotalSeconds + 1);
+            TimeSpan timeSpan = duration.ToTimeSpan();
+            Assert.AreEqual(duration.Seconds, timeSpan.TotalSeconds,1e-3);
+        }
+
+        [Test]
+        public static void ToTimeSpanShouldNotThrowExceptionOnValuesSlightlySmallerThanTimeSpanMax()
+        {
+            Duration duration = Duration.FromSeconds(TimeSpan.MaxValue.TotalSeconds - 1);
+            TimeSpan timeSpan = duration.ToTimeSpan();
+            Assert.AreEqual(duration.Seconds, timeSpan.TotalSeconds, 1e-3);
+        }
+
+        [Test]
+        public static void ExplicitCastToTimeSpanShouldReturnSameValue()
+        {
+            Duration duration = Duration.FromSeconds(60);
+            TimeSpan timeSpan = (TimeSpan)duration;
+            Assert.AreEqual(duration.Seconds, timeSpan.TotalSeconds, 1e-10);
+        }
+
+        [Test]
+        public static void ExplicitCastToDurationShouldReturnSameValue()
+        {
+            TimeSpan timeSpan = TimeSpan.FromSeconds(60);
+            Duration duration = (Duration)timeSpan;
+            Assert.AreEqual(timeSpan.TotalSeconds, duration.Seconds, 1e-10);
+        }
+
+        [Test]
+        public static void DateTimePlusDurationReturnsDateTime()
+        {
+            DateTime dateTime = new DateTime(2016, 1, 1);
+            Duration oneDay = Duration.FromDays(1);
+            DateTime result = dateTime + oneDay;
+            DateTime expected = new DateTime(2016, 1, 2);
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public static void DateTimeMinusDurationReturnsDateTime()
+        {
+            DateTime dateTime = new DateTime(2016, 1, 2);
+            Duration oneDay = Duration.FromDays(1);
+            DateTime result = dateTime - oneDay;
+            DateTime expected = new DateTime(2016, 1, 1);
+            Assert.AreEqual(expected, result);
+        }
     }
 }

--- a/UnitsNet/CustomCode/UnitClasses/Duration.extra.cs
+++ b/UnitsNet/CustomCode/UnitClasses/Duration.extra.cs
@@ -1,0 +1,63 @@
+﻿// Copyright(c) 2007 Andreas Gullberg Larsen
+// https://github.com/anjdreas/UnitsNet
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+
+namespace UnitsNet
+{
+    public partial struct Duration
+    {
+        public static DateTime operator +(DateTime time, Duration duration)
+        {
+            return time.AddSeconds(duration.Seconds);
+        }
+
+        public static DateTime operator -(DateTime time, Duration duration)
+        {
+            return time.AddSeconds(-duration.Seconds);
+        }
+
+        /// <summary>
+        /// Convert a Duration to a TimeSpan.
+        /// </summary>
+        /// <exception cref="ArgumentOutOfRangeException">Throws if the TimeSpan can't represent the Duration exactly </exception>
+        /// <returns>The TimeSpan with the same time as the duration</returns>
+        public TimeSpan ToTimeSpan()
+        {
+            if (Seconds > TimeSpan.MaxValue.TotalSeconds ||
+                Seconds < TimeSpan.MinValue.TotalSeconds)
+            {
+                throw new ArgumentOutOfRangeException(nameof(Duration), "The duration is too large or small to fit in a TimeSpan");
+            }
+            return TimeSpan.FromSeconds(Seconds);
+        }
+
+        public static explicit operator TimeSpan(Duration duration)
+        {
+            return duration.ToTimeSpan();
+        }
+
+        public static explicit operator Duration(TimeSpan duration)
+        {
+            return FromSeconds(duration.TotalSeconds);
+        }
+    }
+}


### PR DESCRIPTION
Added cast and conversion to `TimeSpan` to simplify working with code that requires that. Also added overloads for addition and subtraction in the same way TimeSpan and DateTime works.

I considered adding a property named `TimeSpan` on `Duration` but since `TimeSpan` can't handle large (more than 27000 years) `Duration`'s I went with a function that throws an exception if the value is too large/small.