### PR TITLE
Added (missed) overloads for kinematic viscosity from length and speed

### DIFF
--- a/UnitsNet.Tests/CustomCode/LengthTests.cs
+++ b/UnitsNet.Tests/CustomCode/LengthTests.cs
@@ -98,6 +98,13 @@ namespace UnitsNet.Tests.CustomCode
         }
 
         [Test]
+        public void LengthTimesSpeedEqualsKinematicViscosity()
+        {
+            KinematicViscosity kinematicViscosity = Length.FromMeters(20) * Speed.FromMetersPerSecond(2);
+            Assert.AreEqual(KinematicViscosity.FromSquareMetersPerSecond(40), kinematicViscosity);
+        }
+
+        [Test]
         public void ToStringReturnsCorrectNumberAndUnitWithDefaultUnitWhichIsMeter()
         {
             Length.ToStringDefaultUnit = LengthUnit.Meter;

--- a/UnitsNet.Tests/CustomCode/SpeedTests.cs
+++ b/UnitsNet.Tests/CustomCode/SpeedTests.cs
@@ -119,5 +119,12 @@ namespace UnitsNet.Tests.CustomCode
             Length length = TimeSpan.FromSeconds(2)*Speed.FromMetersPerSecond(20);
             Assert.AreEqual(length, Length.FromMeters(40));
         }
+
+        [Test]
+        public void SpeedTimesLengthEqualsKinematicViscosity()
+        {
+            KinematicViscosity kinematicViscosity = Length.FromMeters(20) * Speed.FromMetersPerSecond(2);
+            Assert.AreEqual(KinematicViscosity.FromSquareMetersPerSecond(40), kinematicViscosity);
+        }
     }
 }

--- a/UnitsNet/CustomCode/UnitClasses/Length.extra.cs
+++ b/UnitsNet/CustomCode/UnitClasses/Length.extra.cs
@@ -97,6 +97,11 @@ namespace UnitsNet
         {
             return Torque.FromNewtonMeters(force.Newtons*length.Meters);
         }
+
+        public static KinematicViscosity operator *(Length length, Speed speed)
+        {
+            return KinematicViscosity.FromSquareMetersPerSecond(length.Meters * speed.MetersPerSecond);
+        }
     }
 
     public class FeetInches

--- a/UnitsNet/CustomCode/UnitClasses/Speed.extra.cs
+++ b/UnitsNet/CustomCode/UnitClasses/Speed.extra.cs
@@ -54,5 +54,10 @@ namespace UnitsNet
         {
             return Length.FromMeters(speed.MetersPerSecond*duration.Seconds);
         }
+
+        public static KinematicViscosity operator *(Speed speed, Length length)
+        {
+            return KinematicViscosity.FromSquareMetersPerSecond(length.Meters * speed.MetersPerSecond);
+        }
     }
 }


### PR DESCRIPTION
Manged to miss these overloads in the earlier pull request