### PR TITLE
Added missing overload for speed. (SpecificEnergy=Speed*Speed)

### DIFF
--- a/UnitsNet.Tests/CustomCode/SpeedTests.cs
+++ b/UnitsNet.Tests/CustomCode/SpeedTests.cs
@@ -119,5 +119,13 @@ namespace UnitsNet.Tests.CustomCode
             Length length = TimeSpan.FromSeconds(2)*Speed.FromMetersPerSecond(20);
             Assert.AreEqual(length, Length.FromMeters(40));
         }
+
+        [Test]
+        public void SpeedTimesSpeedEqualsSpecificEnergy()
+        {
+            //m^2/s^2 = kg*m*m/(s^2*kg) = J/kg
+            SpecificEnergy length = Speed.FromMetersPerSecond(2) * Speed.FromMetersPerSecond(20);
+            Assert.AreEqual(length, SpecificEnergy.FromJoulesPerKilogram(40));
+        }
     }
 }

--- a/UnitsNet/CustomCode/UnitClasses/Speed.extra.cs
+++ b/UnitsNet/CustomCode/UnitClasses/Speed.extra.cs
@@ -54,5 +54,10 @@ namespace UnitsNet
         {
             return Length.FromMeters(speed.MetersPerSecond*duration.Seconds);
         }
+
+        public static SpecificEnergy operator *(Speed left, Speed right)
+        {
+            return SpecificEnergy.FromJoulesPerKilogram(left.MetersPerSecond * right.MetersPerSecond);
+        }
     }
 }


### PR DESCRIPTION
Another missed overload. This one is not that intuitive. 

Found a discussion [here](https://www.physicsforums.com/threads/what-the-heck-is-measured-in-m2-s2.542622/)

`m^2/s^2 = kg*m*m/(s^2*kg) = J/kg`