### PR TITLE
Added overloads related to MassFlow and fuel consumption

### DIFF
--- a/UnitsNet.Tests/CustomCode/BrakeSpecificFuelConsumptionTests.cs
+++ b/UnitsNet.Tests/CustomCode/BrakeSpecificFuelConsumptionTests.cs
@@ -46,5 +46,12 @@ namespace UnitsNet.Tests.CustomCode
             SpecificEnergy massFlow = 2.0 / BrakeSpecificFuelConsumption.FromKilogramsPerJoule(4.0);
             Assert.AreEqual(SpecificEnergy.FromJoulesPerKilogram(0.5), massFlow);
         }
+
+        [Test]
+        public void BrakeSpecificFuelConsumptionTimesSpecificEnergyEqualsEnergy()
+        {
+            double value = BrakeSpecificFuelConsumption.FromKilogramsPerJoule(20.0) * SpecificEnergy.FromJoulesPerKilogram(10.0);
+            Assert.AreEqual(value, 200.0);
+        }
     }
 }

--- a/UnitsNet.Tests/CustomCode/MassFlowTests.cs
+++ b/UnitsNet.Tests/CustomCode/MassFlowTests.cs
@@ -87,5 +87,12 @@ namespace UnitsNet.Tests.CustomCode
             BrakeSpecificFuelConsumption bsfc = MassFlow.FromTonnesPerDay(20) / Power.FromKilowatts(20.0 / 24.0 * 1e6 / 180.0);
             Assert.AreEqual(bsfc.GramsPerKiloWattHour, 180.0, 1e-11);
         }
+
+        [Test]
+        public void MassFlowTimesSpecificEnergyEqualsPower()
+        {
+            Power power = MassFlow.FromKilogramsPerSecond(20.0) * SpecificEnergy.FromJoulesPerKilogram(10.0);
+            Assert.AreEqual(power, Power.FromWatts(200.0));
+        }
     }
 }

--- a/UnitsNet.Tests/CustomCode/PowerTests.cs
+++ b/UnitsNet.Tests/CustomCode/PowerTests.cs
@@ -113,5 +113,19 @@ namespace UnitsNet.Tests.CustomCode
             MassFlow massFlow = Power.FromKilowatts(20.0 / 24.0 * 1e6 / 180.0) * BrakeSpecificFuelConsumption.FromGramsPerKiloWattHour(180.0);
             Assert.AreEqual(massFlow.TonnesPerDay, 20.0, 1e-11);
         }
+
+        [Test]
+        public void PowerDividedByMassFlowEqualsSpecificEnergy()
+        {
+            SpecificEnergy specificEnergy = Power.FromWatts(15.0) / MassFlow.FromKilogramsPerSecond(3);
+            Assert.AreEqual(specificEnergy, SpecificEnergy.FromJoulesPerKilogram(5));
+        }
+
+        [Test]
+        public void PowerDividedBySpecificEnergyEqualsMassFlow()
+        {
+            MassFlow massFlow = Power.FromWatts(15.0) / SpecificEnergy.FromJoulesPerKilogram(3);
+            Assert.AreEqual(massFlow, MassFlow.FromKilogramsPerSecond(5));
+        }
     }
 }

--- a/UnitsNet.Tests/CustomCode/SpecificEnergyTests.cs
+++ b/UnitsNet.Tests/CustomCode/SpecificEnergyTests.cs
@@ -62,5 +62,19 @@ namespace UnitsNet.Tests.CustomCode
             BrakeSpecificFuelConsumption bsfc = 2.0 / SpecificEnergy.FromJoulesPerKilogram(4.0);
             Assert.AreEqual(BrakeSpecificFuelConsumption.FromKilogramsPerJoule(0.5), bsfc);
         }
+
+        [Test]
+        public void SpecificEnergyTimesMassFlowEqualsPower()
+        {
+            Power power = SpecificEnergy.FromJoulesPerKilogram(10.0) * MassFlow.FromKilogramsPerSecond(20.0);
+            Assert.AreEqual(power, Power.FromWatts(200.0));
+        }
+
+        [Test]
+        public void SpecificEnergyTimesBrakeSpecificFuelConsumptionEqualsEnergy()
+        {
+            double value = SpecificEnergy.FromJoulesPerKilogram(10.0) * BrakeSpecificFuelConsumption.FromKilogramsPerJoule(20.0);
+            Assert.AreEqual(value, 200.0);
+        }
     }
 }

--- a/UnitsNet/CustomCode/UnitClasses/BrakeSpecificFuelConsumption.extra.cs
+++ b/UnitsNet/CustomCode/UnitClasses/BrakeSpecificFuelConsumption.extra.cs
@@ -32,5 +32,10 @@ namespace UnitsNet
         {
             return SpecificEnergy.FromJoulesPerKilogram(value / bsfc.KilogramsPerJoule);
         }
+
+        public static double operator *(BrakeSpecificFuelConsumption bsfc, SpecificEnergy specificEnergy)
+        {
+            return specificEnergy.JoulesPerKilogram * bsfc.KilogramsPerJoule;
+        }
     }
 }

--- a/UnitsNet/CustomCode/UnitClasses/MassFlow.extra.cs
+++ b/UnitsNet/CustomCode/UnitClasses/MassFlow.extra.cs
@@ -54,5 +54,10 @@ namespace UnitsNet
         {
             return BrakeSpecificFuelConsumption.FromKilogramsPerJoule(massFlow.KilogramsPerSecond / power.Watts);
         }
+
+        public static Power operator *(MassFlow massFlow, SpecificEnergy specificEnergy)
+        {
+            return Power.FromWatts(massFlow.KilogramsPerSecond * specificEnergy.JoulesPerKilogram);
+        }
     }
 }

--- a/UnitsNet/CustomCode/UnitClasses/Power.extra.cs
+++ b/UnitsNet/CustomCode/UnitClasses/Power.extra.cs
@@ -69,5 +69,15 @@ namespace UnitsNet
         {
             return MassFlow.FromKilogramsPerSecond(bsfc.KilogramsPerJoule * power.Watts);
         }
+
+        public static SpecificEnergy operator /(Power power, MassFlow massFlow)
+        {
+            return SpecificEnergy.FromJoulesPerKilogram(power.Watts / massFlow.KilogramsPerSecond);
+        }
+
+        public static MassFlow operator /(Power power, SpecificEnergy specificEnergy)
+        {
+            return MassFlow.FromKilogramsPerSecond(power.Watts / specificEnergy.JoulesPerKilogram);
+        }
     }
 }

--- a/UnitsNet/CustomCode/UnitClasses/SpecificEnergy.extra.cs
+++ b/UnitsNet/CustomCode/UnitClasses/SpecificEnergy.extra.cs
@@ -33,9 +33,19 @@ namespace UnitsNet
             return Energy.FromJoules(specificEnergy.JoulesPerKilogram*mass.Kilograms);
         }
 
-        public static BrakeSpecificFuelConsumption operator /(double value, SpecificEnergy  bsfc)
+        public static BrakeSpecificFuelConsumption operator /(double value, SpecificEnergy specificEnergy)
         {
-            return BrakeSpecificFuelConsumption.FromKilogramsPerJoule(value / bsfc.JoulesPerKilogram);
+            return BrakeSpecificFuelConsumption.FromKilogramsPerJoule(value / specificEnergy.JoulesPerKilogram);
+        }
+
+        public static double operator *(SpecificEnergy specificEnergy, BrakeSpecificFuelConsumption bsfc)
+        {
+            return specificEnergy.JoulesPerKilogram * bsfc.KilogramsPerJoule;
+        }
+
+        public static Power operator *(SpecificEnergy specificEnergy, MassFlow massFlow)
+        {
+            return Power.FromWatts(massFlow.KilogramsPerSecond * specificEnergy.JoulesPerKilogram);
         }
     }
 }


### PR DESCRIPTION
Added some more overloads. This time for MassFlow and fuel consumption. I think the code I planned to convert now uses UnitsNet so I don't expect to create new pull requests in a while.