### PR TITLE
UnitClass enum

### DIFF
--- a/UnitsNet/GeneratedCode/UnitClass.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClass.g.cs
@@ -1,0 +1,66 @@
+﻿// Copyright © 2007 Andreas Gullberg Larsen (anjdreas@gmail.com).
+// https://github.com/anjdreas/UnitsNet
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// ReSharper disable once CheckNamespace
+
+namespace UnitsNet
+{
+    public enum UnitClass
+    {
+        Undefined = 0,
+        Acceleration,
+        AmplitudeRatio,
+        Angle,
+        Area,
+        BrakeSpecificFuelConsumption,
+        Density,
+        Duration,
+        DynamicViscosity,
+        ElectricCurrent,
+        ElectricPotential,
+        ElectricResistance,
+        Energy,
+        Flow,
+        Force,
+        ForceChangeRate,
+        Frequency,
+        Information,
+        KinematicViscosity,
+        Length,
+        Level,
+        Mass,
+        MassFlow,
+        Power,
+        PowerRatio,
+        Pressure,
+        PressureChangeRate,
+        Ratio,
+        RotationalSpeed,
+        SpecificEnergy,
+        SpecificWeight,
+        Speed,
+        Temperature,
+        TemperatureChangeRate,
+        Torque,
+        VitaminA,
+        Volume,
+    }
+}

--- a/UnitsNet/Scripts/GenerateUnits.ps1
+++ b/UnitsNet/Scripts/GenerateUnits.ps1
@@ -158,6 +158,19 @@ function GenerateUnitSystemDefault($unitClasses, $outDir)
 	Write-Host "(OK) "
 }
 
+function GenerateUnitClassEnum($unitClasses, $outDir)
+{
+    Write-Host -NoNewline "UnitClass.g.cs: "; 
+    $outFileName = "$outDir/UnitClass.g.cs";
+
+    GenerateUnitClassEnumSourceCode $unitClasses | Out-File -Encoding "UTF8" -Force $outFileName | Out-Null;
+	if (!$?) {
+		Write-Host "(error) "
+		exit 1
+	}
+	Write-Host "(OK) "
+}
+
 function EnsureDirExists([String] $dirPath) {
     New-Item -ItemType Directory -Force -Path $dirPath | Out-Null;
 	if (!$?) {
@@ -169,6 +182,7 @@ function EnsureDirExists([String] $dirPath) {
 . "$PSScriptRoot/Include-GenerateTemplates.ps1"
 . "$PSScriptRoot/Include-GenerateLogarithmicCode.ps1"
 . "$PSScriptRoot/Include-GenerateUnitSystemDefaultSourceCode.ps1"
+. "$PSScriptRoot/Include-GenerateUnitClassEnumSourceCode.ps1"
 . "$PSScriptRoot/Include-GenerateUnitClassSourceCode.ps1"
 . "$PSScriptRoot/Include-GenerateUnitEnumSourceCode.ps1"
 . "$PSScriptRoot/Include-GenerateUnitTestBaseClassSourceCode.ps1"
@@ -218,6 +232,9 @@ get-childitem -path $templatesDir -filter "*.json" | % {
 
 Write-Host ""
 GenerateUnitSystemDefault $unitClasses $unitSystemDir
+
+Write-Host ""
+GenerateUnitClassEnum $unitClasses $unitSystemDir
 
 Write-Host ""
 Write-Host ""

--- a/UnitsNet/Scripts/Include-GenerateUnitClassEnumSourceCode.ps1
+++ b/UnitsNet/Scripts/Include-GenerateUnitClassEnumSourceCode.ps1
@@ -1,0 +1,39 @@
+function GenerateUnitClassEnumSourceCode($unitClasses)
+{
+@"
+// Copyright © 2007 Andreas Gullberg Larsen (anjdreas@gmail.com).
+// https://github.com/anjdreas/UnitsNet
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// ReSharper disable once CheckNamespace
+
+namespace UnitsNet
+{
+    public enum UnitClass
+    {
+        Undefined = 0,
+"@; foreach ($unitClass in $unitClasses) {
+@"
+        $($unitClass.Name),
+"@; }@"
+    }
+}
+"@;
+}


### PR DESCRIPTION
Hi, this is an incremental step for #186.  This simply adds the PowerShell scripting for generating a UnitClass enum which would then be available for use in external code.

Please review for naming, file locations, etc.

Merging in this change would be helpful to me as I could then remove my hand-rolled enum in my application and adopt the UnitsNet.UnitClass enum instead.