### PR TITLE
Force from mass and acceleration overloads

### DIFF
--- a/UnitsNet.Tests/CustomCode/ForceTests.cs
+++ b/UnitsNet.Tests/CustomCode/ForceTests.cs
@@ -68,6 +68,13 @@ namespace UnitsNet.Tests.CustomCode
             Acceleration acceleration = Force.FromNewtons(27)/Mass.FromKilograms(9);
             Assert.AreEqual(acceleration, Acceleration.FromMeterPerSecondSquared(3));
         }
+    
+        [Test]
+        public void ForceDividedByAccelerationEqualsMass()
+        {
+          Mass acceleration = Force.FromNewtons(200)/Acceleration.FromMeterPerSecondSquared(50);
+          Assert.AreEqual(acceleration, Mass.FromKilograms(4));
+        }
 
         [Test]
         public void MassByAccelerationEqualsForceUsingDouble()

--- a/UnitsNet.Tests/CustomCode/ForceTests.cs
+++ b/UnitsNet.Tests/CustomCode/ForceTests.cs
@@ -61,8 +61,7 @@ namespace UnitsNet.Tests.CustomCode
             var force = Force.FromPressureByArea(Pressure.FromNewtonsPerSquareMeter(6), Length2d.FromMeters(5, 2));
             Assert.AreEqual(force, Force.FromNewtons(60));
         }
-
-
+    
         [Test]
         public void ForceDividedByMassEqualsAcceleration()
         {
@@ -71,13 +70,16 @@ namespace UnitsNet.Tests.CustomCode
         }
 
         [Test]
+        public void MassByAccelerationEqualsForceUsingDouble()
+        {
+            var force = Force.FromMassByAcceleration(Mass.FromKilograms(9), 3);
+            Assert.AreEqual(force, Force.FromNewtons(27));
+        }
+        [Test]
         public void MassByAccelerationEqualsForce()
         {
-            Force force = Force.FromMassByAcceleration(Mass.FromKilograms(9), Acceleration.FromMeterPerSecondSquared(3));
-            Assert.AreEqual(force, Force.FromNewtons(27));
-
-            force = Force.FromMassByAcceleration(Mass.FromKilograms(9), 3);
-            Assert.AreEqual(force, Force.FromNewtons(27));
+            Force force = Force.FromMassByAcceleration(Mass.FromKilograms(85), Acceleration.FromMeterPerSecondSquared(-4));
+            Assert.AreEqual(force, Force.FromNewtons(-340));
         }
 
         [Test]

--- a/UnitsNet.Tests/CustomCode/ForceTests.cs
+++ b/UnitsNet.Tests/CustomCode/ForceTests.cs
@@ -56,6 +56,16 @@ namespace UnitsNet.Tests.CustomCode
         }
 
         [Test]
+        public void MassByAccelerationEqualsForce()
+        {
+            Force force = Force.FromMassByAcceleration(Mass.FromKilograms(9), Acceleration.FromMeterPerSecondSquared(3));
+            Assert.AreEqual(force, Force.FromNewtons(27));
+
+            force = Force.FromMassByAcceleration(Mass.FromKilograms(9), 3);
+            Assert.AreEqual(force, Force.FromNewtons(27));
+        }
+
+        [Test]
         public void ForceTimesSpeedEqualsPower()
         {
             Power power = Force.FromNewtons(27.0)*Speed.FromMetersPerSecond(10.0);

--- a/UnitsNet.Tests/CustomCode/ForceTests.cs
+++ b/UnitsNet.Tests/CustomCode/ForceTests.cs
@@ -49,17 +49,21 @@ namespace UnitsNet.Tests.CustomCode
         }
 
         [Test]
-        public void PressureByAreaEqualsForce()
+        public void PressureByAreaEqualsForceUsingArea()
         {
-            Force force = Force.FromPressureByArea(Pressure.FromNewtonsPerSquareMeter(9), Area.FromSquareMeters(9));
-            Assert.AreEqual(force, Force.FromNewtons(81));
+            Force force = Force.FromPressureByArea(Pressure.FromNewtonsPerSquareMeter(5), Area.FromSquareMeters(7));
+            Assert.AreEqual(force, Force.FromNewtons(35));
+        }
 
-            force = Force.FromPressureByArea(Pressure.FromNewtonsPerSquareMeter(9), Length2d.FromMeters(3, 3));
-            Assert.AreEqual(force, Force.FromNewtons(81));
+        [Test]
+        public void PressureByAreaEqualsForceUsingLength2D()
+        {
+            var force = Force.FromPressureByArea(Pressure.FromNewtonsPerSquareMeter(6), Length2d.FromMeters(5, 2));
+            Assert.AreEqual(force, Force.FromNewtons(60));
         }
 
 
-       [Test]
+        [Test]
         public void ForceDividedByMassEqualsAcceleration()
         {
             Acceleration acceleration = Force.FromNewtons(27)/Mass.FromKilograms(9);

--- a/UnitsNet.Tests/CustomCode/ForceTests.cs
+++ b/UnitsNet.Tests/CustomCode/ForceTests.cs
@@ -49,6 +49,17 @@ namespace UnitsNet.Tests.CustomCode
         }
 
         [Test]
+        public void PressureByAreaEqualsForce()
+        {
+            Force force = Force.FromPressureByArea(Pressure.FromNewtonsPerSquareMeter(9), Area.FromSquareMeters(9));
+            Assert.AreEqual(force, Force.FromNewtons(81));
+
+            force = Force.FromPressureByArea(Pressure.FromNewtonsPerSquareMeter(9), Length2d.FromMeters(3, 3));
+            Assert.AreEqual(force, Force.FromNewtons(81));
+        }
+
+
+       [Test]
         public void ForceDividedByMassEqualsAcceleration()
         {
             Acceleration acceleration = Force.FromNewtons(27)/Mass.FromKilograms(9);

--- a/UnitsNet/CustomCode/UnitClasses/Force.extra.cs
+++ b/UnitsNet/CustomCode/UnitClasses/Force.extra.cs
@@ -41,10 +41,15 @@ namespace UnitsNet
 
         public static Acceleration operator /(Force force, Mass mass)
         {
-            return Acceleration.FromMeterPerSecondSquared(force.Newtons/mass.Kilograms);
+          return Acceleration.FromMeterPerSecondSquared(force.Newtons / mass.Kilograms);
         }
 
-        public static Pressure operator /(Force force, Area area)
+        public static Mass operator /(Force force, Acceleration mass)
+        {
+          return Mass.FromKilograms(force.Newtons / mass.MeterPerSecondSquared);
+        }
+
+    public static Pressure operator /(Force force, Area area)
         {
             return Pressure.FromPascals(force.Newtons/area.SquareMeters);
         }

--- a/UnitsNet/CustomCode/UnitClasses/Force.extra.cs
+++ b/UnitsNet/CustomCode/UnitClasses/Force.extra.cs
@@ -70,5 +70,10 @@ namespace UnitsNet
         {
             return new Force(mass.Kilograms*metersPerSecondSquared);
         }
+
+        public static Force FromMassByAcceleration(Mass mass, Acceleration acceleration)
+        {
+            return new Force(mass.Kilograms * acceleration.MeterPerSecondSquared);
+        }
     }
 }

--- a/UnitsNet/CustomCode/UnitClasses/Force.extra.cs
+++ b/UnitsNet/CustomCode/UnitClasses/Force.extra.cs
@@ -58,17 +58,17 @@ namespace UnitsNet
             double newtons = p.Pascals*metersSquared;
             return new Force(newtons);
         }
+
+        public static Force FromMassByAcceleration(Mass mass, double metersPerSecondSquared)
+        {
+          return new Force(mass.Kilograms * metersPerSecondSquared);
+        }
 #endif
 
         public static Force FromPressureByArea(Pressure p, Area area)
         {
             double newtons = p.Pascals*area.SquareMeters;
             return new Force(newtons);
-        }
-
-        public static Force FromMassByAcceleration(Mass mass, double metersPerSecondSquared)
-        {
-            return new Force(mass.Kilograms*metersPerSecondSquared);
         }
 
         public static Force FromMassByAcceleration(Mass mass, Acceleration acceleration)


### PR DESCRIPTION
Previously there was only Force.FromMassByAcceleration(Mass, double)
This pull request adds Force.FromMassByAcceleration(Mass, Acceleration)