### PR TITLE
Created AcPotential unit

### DIFF
--- a/UnitsNet.Tests/CustomCode/AcPotentialTests.cs
+++ b/UnitsNet.Tests/CustomCode/AcPotentialTests.cs
@@ -33,20 +33,20 @@ namespace UnitsNet.Tests.CustomCode
     [Test]
     public void FromElectricPotential()
     {
-      Assert.AreEqual(2.5, AcPotential.FromPeakElectricalPotential(ElectricPotential.FromMillivolts(2500)).VoltsPeak);
-      Assert.AreEqual(102.5, AcPotential.FromRMSElectricalPotential(ElectricPotential.FromVolts(102.5)).VoltsRMS);
+      Assert.AreEqual(2.5, AcPotential.FromPeakElectricalPotential(ElectricPotential.FromMillivolts(2500)).VoltsPeak, VoltsPeakTolerance);
+      Assert.AreEqual(102.5, AcPotential.FromRMSElectricalPotential(ElectricPotential.FromVolts(102.5)).VoltsRMS, VoltsRMSTolerance);
     }
 
     [Test]
     public void TakesAbsoluteValueOfInput()
     {
-      Assert.AreEqual(1.4, new AcPotential((decimal) -1.4).VoltsPeak);
-      Assert.AreEqual(12,new AcPotential((long) -12).VoltsPeak);
-      Assert.AreEqual(1.2,new AcPotential(-1.2).VoltsPeak);
-      Assert.AreEqual(15,new AcPotential(-15).VoltsPeak);
-      Assert.AreEqual(2,AcPotential.FromVoltsPeak(-2).VoltsPeak);
-      Assert.AreEqual(2.45,AcPotential.FromVoltsPeakToPeak(-2.45).VoltsPeakToPeak);
-      Assert.AreEqual(2.78,AcPotential.FromVoltsRMS(-2.78).VoltsRMS);
+      Assert.AreEqual(1.4, new AcPotential((decimal) -1.4).VoltsPeak, VoltsPeakTolerance);
+      Assert.AreEqual(12,new AcPotential((long) -12).VoltsPeak, VoltsPeakTolerance);
+      Assert.AreEqual(1.2,new AcPotential(-1.2).VoltsPeak, VoltsPeakTolerance);
+      Assert.AreEqual(15,new AcPotential(-15).VoltsPeak, VoltsPeakTolerance);
+      Assert.AreEqual(2,AcPotential.FromVoltsPeak(-2).VoltsPeak, VoltsPeakTolerance);
+      Assert.AreEqual(2.45,AcPotential.FromVoltsPeakToPeak(-2.45).VoltsPeakToPeak, VoltsPeakToPeakTolerance);
+      Assert.AreEqual(2.78, AcPotential.FromVoltsRMS(-2.78).VoltsRMS, VoltsRMSTolerance);
     }
   }
 }

--- a/UnitsNet.Tests/CustomCode/AcPotentialTests.cs
+++ b/UnitsNet.Tests/CustomCode/AcPotentialTests.cs
@@ -41,11 +41,11 @@ namespace UnitsNet.Tests.CustomCode
     public void TakesAbsoluteValueOfInput()
     {
       Assert.AreEqual(1.4, new AcPotential((decimal) -1.4).VoltsPeak, VoltsPeakTolerance);
-      Assert.AreEqual(12,new AcPotential((long) -12).VoltsPeak, VoltsPeakTolerance);
-      Assert.AreEqual(1.2,new AcPotential(-1.2).VoltsPeak, VoltsPeakTolerance);
-      Assert.AreEqual(15,new AcPotential(-15).VoltsPeak, VoltsPeakTolerance);
-      Assert.AreEqual(2,AcPotential.FromVoltsPeak(-2).VoltsPeak, VoltsPeakTolerance);
-      Assert.AreEqual(2.45,AcPotential.FromVoltsPeakToPeak(-2.45).VoltsPeakToPeak, VoltsPeakToPeakTolerance);
+      Assert.AreEqual(12, new AcPotential(-12).VoltsPeak, VoltsPeakTolerance);
+      Assert.AreEqual(1.2, new AcPotential(-1.2).VoltsPeak, VoltsPeakTolerance);
+      Assert.AreEqual(15, new AcPotential(-15).VoltsPeak, VoltsPeakTolerance);
+      Assert.AreEqual(2, AcPotential.FromVoltsPeak(-2).VoltsPeak, VoltsPeakTolerance);
+      Assert.AreEqual(2.45, AcPotential.FromVoltsPeakToPeak(-2.45).VoltsPeakToPeak, VoltsPeakToPeakTolerance);
       Assert.AreEqual(2.78, AcPotential.FromVoltsRMS(-2.78).VoltsRMS, VoltsRMSTolerance);
     }
   }

--- a/UnitsNet.Tests/CustomCode/AcPotentialTests.cs
+++ b/UnitsNet.Tests/CustomCode/AcPotentialTests.cs
@@ -1,0 +1,52 @@
+﻿// Copyright © 2007 Andreas Gullberg Larsen (anjdreas@gmail.com).
+// https://github.com/anjdreas/UnitsNet
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using NUnit.Framework;
+
+namespace UnitsNet.Tests.CustomCode
+{
+  public class AcPotentialTests : AcPotentialTestsBase
+  {
+    // TODO Override properties in base class here
+    protected override double VoltsPeakInOneVoltPeak => 1;
+    protected override double VoltsPeakToPeakInOneVoltPeak => 2;
+    protected override double VoltsRMSInOneVoltPeak => 0.7071067811865475244008443621048490393;
+
+    [Test]
+    public void FromElectricPotential()
+    {
+      Assert.AreEqual(2.5, AcPotential.FromPeakElectricalPotential(ElectricPotential.FromMillivolts(2500)).VoltsPeak);
+      Assert.AreEqual(102.5, AcPotential.FromRMSElectricalPotential(ElectricPotential.FromVolts(102.5)).VoltsRMS);
+    }
+
+    [Test]
+    public void TakesAbsoluteValueOfInput()
+    {
+      Assert.AreEqual(1.4, new AcPotential((decimal) -1.4).VoltsPeak);
+      Assert.AreEqual(12,new AcPotential((long) -12).VoltsPeak);
+      Assert.AreEqual(1.2,new AcPotential(-1.2).VoltsPeak);
+      Assert.AreEqual(15,new AcPotential(-15).VoltsPeak);
+      Assert.AreEqual(2,AcPotential.FromVoltsPeak(-2).VoltsPeak);
+      Assert.AreEqual(2.45,AcPotential.FromVoltsPeakToPeak(-2.45).VoltsPeakToPeak);
+      Assert.AreEqual(2.78,AcPotential.FromVoltsRMS(-2.78).VoltsRMS);
+    }
+  }
+}

--- a/UnitsNet.Tests/CustomCode/AmplitudeRatioTests.cs
+++ b/UnitsNet.Tests/CustomCode/AmplitudeRatioTests.cs
@@ -68,6 +68,18 @@ namespace UnitsNet.Tests.CustomCode
             return AmplitudeRatio.FromElectricPotential(v).DecibelVolts;
         }
 
+        [TestCase(1, Result = 0)]
+        [TestCase(10, Result = 20)]
+        [TestCase(100, Result = 40)]
+        [TestCase(1000, Result = 60)]
+        public double ExpectAcVoltageConvertedToAmplitudeRatioCorrectly(double voltage)
+        {
+          // Amplitude ratio increases linearly by 20 dBV with power-of-10 increases of voltage.
+          AcPotential v = AcPotential.FromVoltsRMS(voltage);
+
+          return AmplitudeRatio.FromAcPotential(v).DecibelVolts;
+        }
+
         [TestCase(-40, Result = 0.01)]
         [TestCase(-20, Result = 0.1)]
         [TestCase(0, Result = 1)]
@@ -79,6 +91,20 @@ namespace UnitsNet.Tests.CustomCode
             AmplitudeRatio ar = AmplitudeRatio.FromDecibelVolts(amplitudeRatio);
 
             return AmplitudeRatio.ToElectricPotential(ar).Volts;
+        }
+
+
+        [TestCase(-40, Result = 0.01)]
+        [TestCase(-20, Result = 0.1)]
+        [TestCase(0, Result = 1)]
+        [TestCase(20, Result = 10)]
+        [TestCase(40, Result = 100)]
+        public double ExpectAmplitudeRatioConvertedToAcPotentialCorrectly(double amplitudeRatio)
+        {
+          // Voltage increases by powers of 10 for every 20 dBV increase in amplitude ratio.
+          AmplitudeRatio ar = AmplitudeRatio.FromDecibelVolts(amplitudeRatio);
+
+          return AmplitudeRatio.ToAcPotential(ar).VoltsRMS;
         }
 
         // http://www.maximintegrated.com/en/app-notes/index.mvp/id/808

--- a/UnitsNet.Tests/GeneratedCode/AcPotentialTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/AcPotentialTestsBase.g.cs
@@ -1,0 +1,179 @@
+﻿// Copyright © 2007 Andreas Gullberg Larsen (anjdreas@gmail.com).
+// https://github.com/anjdreas/UnitsNet
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using NUnit.Framework;
+using UnitsNet.Units;
+
+// Disable build warning CS1718: Comparison made to same variable; did you mean to compare something else?
+#pragma warning disable 1718
+
+// ReSharper disable once CheckNamespace
+namespace UnitsNet.Tests
+{
+    /// <summary>
+    /// Test of AcPotential.
+    /// </summary>
+    [TestFixture]
+// ReSharper disable once PartialTypeWithSinglePart
+    public abstract partial class AcPotentialTestsBase
+    {
+        protected abstract double VoltsPeakInOneVoltPeak { get; }
+        protected abstract double VoltsPeakToPeakInOneVoltPeak { get; }
+        protected abstract double VoltsRMSInOneVoltPeak { get; }
+
+// ReSharper disable VirtualMemberNeverOverriden.Global
+        protected virtual double VoltsPeakTolerance { get { return 1e-5; } }
+        protected virtual double VoltsPeakToPeakTolerance { get { return 1e-5; } }
+        protected virtual double VoltsRMSTolerance { get { return 1e-5; } }
+// ReSharper restore VirtualMemberNeverOverriden.Global
+
+        [Test]
+        public void VoltPeakToAcPotentialUnits()
+        {
+            AcPotential voltpeak = AcPotential.FromVoltsPeak(1);
+            Assert.AreEqual(VoltsPeakInOneVoltPeak, voltpeak.VoltsPeak, VoltsPeakTolerance);
+            Assert.AreEqual(VoltsPeakToPeakInOneVoltPeak, voltpeak.VoltsPeakToPeak, VoltsPeakToPeakTolerance);
+            Assert.AreEqual(VoltsRMSInOneVoltPeak, voltpeak.VoltsRMS, VoltsRMSTolerance);
+        }
+
+        [Test]
+        public void FromValueAndUnit()
+        {
+            Assert.AreEqual(1, AcPotential.From(1, AcPotentialUnit.VoltPeak).VoltsPeak, VoltsPeakTolerance);
+            Assert.AreEqual(1, AcPotential.From(1, AcPotentialUnit.VoltPeakToPeak).VoltsPeakToPeak, VoltsPeakToPeakTolerance);
+            Assert.AreEqual(1, AcPotential.From(1, AcPotentialUnit.VoltRMS).VoltsRMS, VoltsRMSTolerance);
+        }
+
+        [Test]
+        public void As()
+        {
+            var voltpeak = AcPotential.FromVoltsPeak(1);
+            Assert.AreEqual(VoltsPeakInOneVoltPeak, voltpeak.As(AcPotentialUnit.VoltPeak), VoltsPeakTolerance);
+            Assert.AreEqual(VoltsPeakToPeakInOneVoltPeak, voltpeak.As(AcPotentialUnit.VoltPeakToPeak), VoltsPeakToPeakTolerance);
+            Assert.AreEqual(VoltsRMSInOneVoltPeak, voltpeak.As(AcPotentialUnit.VoltRMS), VoltsRMSTolerance);
+        }
+
+        [Test]
+        public void ConversionRoundTrip()
+        {
+            AcPotential voltpeak = AcPotential.FromVoltsPeak(1);
+            Assert.AreEqual(1, AcPotential.FromVoltsPeak(voltpeak.VoltsPeak).VoltsPeak, VoltsPeakTolerance);
+            Assert.AreEqual(1, AcPotential.FromVoltsPeakToPeak(voltpeak.VoltsPeakToPeak).VoltsPeak, VoltsPeakToPeakTolerance);
+            Assert.AreEqual(1, AcPotential.FromVoltsRMS(voltpeak.VoltsRMS).VoltsPeak, VoltsRMSTolerance);
+        }
+
+        [Test]
+        public void ArithmeticOperators()
+        {
+            AcPotential v = AcPotential.FromVoltsPeak(1);
+            Assert.AreEqual(-1, -v.VoltsPeak, VoltsPeakTolerance);
+            Assert.AreEqual(2, (AcPotential.FromVoltsPeak(3)-v).VoltsPeak, VoltsPeakTolerance);
+            Assert.AreEqual(2, (v + v).VoltsPeak, VoltsPeakTolerance);
+            Assert.AreEqual(10, (v*10).VoltsPeak, VoltsPeakTolerance);
+            Assert.AreEqual(10, (10*v).VoltsPeak, VoltsPeakTolerance);
+            Assert.AreEqual(2, (AcPotential.FromVoltsPeak(10)/5).VoltsPeak, VoltsPeakTolerance);
+            Assert.AreEqual(2, AcPotential.FromVoltsPeak(10)/AcPotential.FromVoltsPeak(5), VoltsPeakTolerance);
+        }
+
+        [Test]
+        public void ComparisonOperators()
+        {
+            AcPotential oneVoltPeak = AcPotential.FromVoltsPeak(1);
+            AcPotential twoVoltsPeak = AcPotential.FromVoltsPeak(2);
+
+            Assert.True(oneVoltPeak < twoVoltsPeak);
+            Assert.True(oneVoltPeak <= twoVoltsPeak);
+            Assert.True(twoVoltsPeak > oneVoltPeak);
+            Assert.True(twoVoltsPeak >= oneVoltPeak);
+
+            Assert.False(oneVoltPeak > twoVoltsPeak);
+            Assert.False(oneVoltPeak >= twoVoltsPeak);
+            Assert.False(twoVoltsPeak < oneVoltPeak);
+            Assert.False(twoVoltsPeak <= oneVoltPeak);
+        }
+
+        [Test]
+        public void CompareToIsImplemented()
+        {
+            AcPotential voltpeak = AcPotential.FromVoltsPeak(1);
+            Assert.AreEqual(0, voltpeak.CompareTo(voltpeak));
+            Assert.Greater(voltpeak.CompareTo(AcPotential.Zero), 0);
+            Assert.Less(AcPotential.Zero.CompareTo(voltpeak), 0);
+        }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentException))]
+        public void CompareToThrowsOnTypeMismatch()
+        {
+            AcPotential voltpeak = AcPotential.FromVoltsPeak(1);
+// ReSharper disable once ReturnValueOfPureMethodIsNotUsed
+            voltpeak.CompareTo(new object());
+        }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void CompareToThrowsOnNull()
+        {
+            AcPotential voltpeak = AcPotential.FromVoltsPeak(1);
+// ReSharper disable once ReturnValueOfPureMethodIsNotUsed
+            voltpeak.CompareTo(null);
+        }
+
+
+        [Test]
+        public void EqualityOperators()
+        {
+            AcPotential a = AcPotential.FromVoltsPeak(1);
+            AcPotential b = AcPotential.FromVoltsPeak(2);
+
+// ReSharper disable EqualExpressionComparison
+            Assert.True(a == a);
+            Assert.True(a != b);
+
+            Assert.False(a == b);
+            Assert.False(a != a);
+// ReSharper restore EqualExpressionComparison
+        }
+
+        [Test]
+        public void EqualsIsImplemented()
+        {
+            AcPotential v = AcPotential.FromVoltsPeak(1);
+            Assert.IsTrue(v.Equals(AcPotential.FromVoltsPeak(1)));
+            Assert.IsFalse(v.Equals(AcPotential.Zero));
+        }
+
+        [Test]
+        public void EqualsReturnsFalseOnTypeMismatch()
+        {
+            AcPotential voltpeak = AcPotential.FromVoltsPeak(1);
+            Assert.IsFalse(voltpeak.Equals(new object()));
+        }
+
+        [Test]
+        public void EqualsReturnsFalseOnNull()
+        {
+            AcPotential voltpeak = AcPotential.FromVoltsPeak(1);
+            Assert.IsFalse(voltpeak.Equals(null));
+        }
+    }
+}

--- a/UnitsNet/CustomCode/Extensions/AmplitudeRatioExtensions.cs
+++ b/UnitsNet/CustomCode/Extensions/AmplitudeRatioExtensions.cs
@@ -42,6 +42,21 @@ namespace UnitsNet.CustomCode.Extensions
         }
 
         /// <summary>
+        ///     Gets an <see cref="ElectricPotential" /> from <see cref="AcPotential" />.
+        /// </summary>
+        /// <paramref name="amplitudeRatio">The amplitude ratio to convert.</paramref>
+        /// <remarks>
+        ///     Provides a nicer syntax for converting an amplitude ratio back to an ac voltage.
+        ///     <example>
+        ///         <c>var voltage = voltageRatio.ToAcPotential();</c>
+        ///     </example>
+        /// </remarks>
+        public static AcPotential ToAcPotential(this AmplitudeRatio amplitudeRatio)
+        {
+          return AmplitudeRatio.ToAcPotential(amplitudeRatio);
+        }
+
+        /// <summary>
         ///     Converts a <see cref="AmplitudeRatio" /> to a <see cref="PowerRatio" />.
         /// </summary>
         /// <param name="amplitudeRatio">The amplitude ratio to convert.</param>

--- a/UnitsNet/CustomCode/UnitClasses/AcPotential.extra.cs
+++ b/UnitsNet/CustomCode/UnitClasses/AcPotential.extra.cs
@@ -19,49 +19,24 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-// ReSharper disable once CheckNamespace
+using System;
 
 namespace UnitsNet
 {
-    public enum UnitClass
+#if WINDOWS_UWP
+    public sealed partial class AcPotential
+#else
+    public partial struct AcPotential
+#endif
     {
-        Undefined = 0,
-        Acceleration,
-        AcPotential,
-        AmplitudeRatio,
-        Angle,
-        Area,
-        BrakeSpecificFuelConsumption,
-        Density,
-        Duration,
-        DynamicViscosity,
-        ElectricCurrent,
-        ElectricPotential,
-        ElectricResistance,
-        Energy,
-        Flow,
-        Force,
-        ForceChangeRate,
-        Frequency,
-        Information,
-        KinematicViscosity,
-        Length,
-        Level,
-        Mass,
-        MassFlow,
-        Power,
-        PowerRatio,
-        Pressure,
-        PressureChangeRate,
-        Ratio,
-        RotationalSpeed,
-        SpecificEnergy,
-        SpecificWeight,
-        Speed,
-        Temperature,
-        TemperatureChangeRate,
-        Torque,
-        VitaminA,
-        Volume,
+      public static AcPotential FromPeakElectricalPotential(ElectricPotential voltsPeak)
+      {
+        return AcPotential.FromVoltsPeak(voltsPeak.Volts);
+      }
+
+      public static AcPotential FromRMSElectricalPotential(ElectricPotential voltsRMS)
+      { 
+        return AcPotential.FromVoltsRMS(voltsRMS.Volts);
+      }
     }
 }

--- a/UnitsNet/CustomCode/UnitClasses/AmplitudeRatio.extra.cs
+++ b/UnitsNet/CustomCode/UnitClasses/AmplitudeRatio.extra.cs
@@ -20,6 +20,7 @@
 // THE SOFTWARE.
 
 using System;
+using UnitsNet.CustomCode.Extensions;
 
 namespace UnitsNet
 {
@@ -29,21 +30,37 @@ namespace UnitsNet
     public partial struct AmplitudeRatio
 #endif
     {
-        /// <summary>
-        ///     Initializes a new instance of the <see cref="AmplitudeRatio" /> struct from the specified electric potential
-        ///     referenced to one volt RMS. This assumes both the specified electric potential and the one volt reference have the
-        ///     same
-        ///     resistance.
-        /// </summary>
-        /// <param name="voltage">The electric potential referenced to one volt.</param>
-        // Operator overloads not supported in Universal Windows Platform (WinRT Components)
+
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="AmplitudeRatio" /> struct from the specified <see cref="AcPotential" />.
+    /// </summary>
+    /// <param name="acVoltage">AC voltage signal.</param>
+    // Operator overloads not supported in Universal Windows Platform (WinRT Components)
 #if WINDOWS_UWP
         internal
 #else
-        public
+    public
 #endif
-            AmplitudeRatio(ElectricPotential voltage)
-            : this()
+        AmplitudeRatio(AcPotential acVoltage) : this()
+        {
+          // E(dBV) = 20*log10(value(V)/reference(V))
+          _decibelVolts = 20 * Math.Log10(acVoltage.VoltsRMS / 1);
+        }
+
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="AmplitudeRatio" /> struct from the specified <see cref="ElectricPotential" />
+    ///     referenced to one volt RMS. This assumes both the specified electric potential and the one volt reference have the
+    ///     same
+    ///     resistance.
+    /// </summary>
+    /// <param name="voltage">The electric potential referenced to one volt.</param>
+    // Operator overloads not supported in Universal Windows Platform (WinRT Components)
+#if WINDOWS_UWP
+        internal
+#else
+    public
+#endif
+        AmplitudeRatio(ElectricPotential voltage) : this()
         {
             if (voltage.Volts <= 0)
                 throw new ArgumentOutOfRangeException(
@@ -58,14 +75,24 @@ namespace UnitsNet
         ///     Gets an <see cref="AmplitudeRatio" /> in decibels (dB) relative to 1 volt RMS from an
         ///     <see cref="ElectricPotential" />.
         /// </summary>
-        /// <param name="voltage">The voltage (electric potential) relative to one volt RMS.</param>
+        /// <param name="voltage">The voltage (electric potential) to express as an amplitude.</param>
         public static AmplitudeRatio FromElectricPotential(ElectricPotential voltage)
         {
             return new AmplitudeRatio(voltage);
         }
 
         /// <summary>
-        ///     Gets an <see cref="ElectricPotential" /> from <see cref="AmplitudeRatio" />.
+        ///     Gets an <see cref="AmplitudeRatio" /> in decibels (dB) relative to 1 volt RMS from an
+        ///     <see cref="AcPotential" />.
+        /// </summary>
+        /// <param name="acVoltage">The voltage (ac potential) signal to express as an amplitude.</param>
+        public static AmplitudeRatio FromAcPotential(AcPotential acVoltage)
+        {
+          return new AmplitudeRatio(acVoltage);
+        }
+
+        /// <summary>
+        ///     Gets an <see cref="ElectricPotential" /> from <see cref="AmplitudeRatio" /> as RMS.
         /// </summary>
         /// <param name="voltageRatio">The voltage ratio to convert to voltage (electric potential).</param>
         public static ElectricPotential ToElectricPotential(AmplitudeRatio voltageRatio)
@@ -73,6 +100,17 @@ namespace UnitsNet
             // E(V) = 1V * 10^(E(dBV)/20)
             return ElectricPotential.FromVolts(Math.Pow(10, voltageRatio._decibelVolts/20));
         }
+
+        /// <summary>
+        ///     Gets an <see cref="AcPotential" /> from <see cref="AmplitudeRatio" />.
+        /// </summary>
+        /// <param name="voltageRatio">The voltage ratio to convert to voltage (ac potential).</param>
+        public static AcPotential ToAcPotential(AmplitudeRatio voltageRatio)
+        {
+          ElectricPotential electricPotential = voltageRatio.ToElectricPotential();
+          return AcPotential.FromVoltsRMS(electricPotential.Volts);
+        }
+
 
         /// <summary>
         ///     Converts a <see cref="AmplitudeRatio" /> to a <see cref="PowerRatio" />.

--- a/UnitsNet/GeneratedCode/Enums/AcPotentialUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Enums/AcPotentialUnit.g.cs
@@ -1,16 +1,16 @@
 ﻿// Copyright © 2007 Andreas Gullberg Larsen (anjdreas@gmail.com).
 // https://github.com/anjdreas/UnitsNet
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -20,48 +20,13 @@
 // THE SOFTWARE.
 
 // ReSharper disable once CheckNamespace
-
-namespace UnitsNet
+namespace UnitsNet.Units
 {
-    public enum UnitClass
+    public enum AcPotentialUnit
     {
         Undefined = 0,
-        Acceleration,
-        AcPotential,
-        AmplitudeRatio,
-        Angle,
-        Area,
-        BrakeSpecificFuelConsumption,
-        Density,
-        Duration,
-        DynamicViscosity,
-        ElectricCurrent,
-        ElectricPotential,
-        ElectricResistance,
-        Energy,
-        Flow,
-        Force,
-        ForceChangeRate,
-        Frequency,
-        Information,
-        KinematicViscosity,
-        Length,
-        Level,
-        Mass,
-        MassFlow,
-        Power,
-        PowerRatio,
-        Pressure,
-        PressureChangeRate,
-        Ratio,
-        RotationalSpeed,
-        SpecificEnergy,
-        SpecificWeight,
-        Speed,
-        Temperature,
-        TemperatureChangeRate,
-        Torque,
-        VitaminA,
-        Volume,
+        VoltPeak,
+        VoltPeakToPeak,
+        VoltRMS,
     }
 }

--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToAcPotentialExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToAcPotentialExtensions.g.cs
@@ -1,0 +1,134 @@
+﻿// Copyright (c) 2007 Andreas Gullberg Larsen (anjdreas@gmail.com).
+// https://github.com/anjdreas/UnitsNet
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+
+#if !WINDOWS_UWP
+// Extension methods/overloads not supported in Universal Windows Platform (WinRT Components)
+namespace UnitsNet.Extensions.NumberToAcPotential
+{
+    public static class NumberToAcPotentialExtensions
+    {
+        #region VoltPeak
+
+        /// <inheritdoc cref="AcPotential.FromVoltsPeak(double)"/>
+        public static AcPotential VoltsPeak(this int value) => AcPotential.FromVoltsPeak(value);
+
+        /// <inheritdoc cref="AcPotential.FromVoltsPeak(double?)"/>
+        public static AcPotential? VoltsPeak(this int? value) => AcPotential.FromVoltsPeak(value);
+
+        /// <inheritdoc cref="AcPotential.FromVoltsPeak(double)"/>
+        public static AcPotential VoltsPeak(this long value) => AcPotential.FromVoltsPeak(value);
+
+        /// <inheritdoc cref="AcPotential.FromVoltsPeak(double?)"/>
+        public static AcPotential? VoltsPeak(this long? value) => AcPotential.FromVoltsPeak(value);
+
+        /// <inheritdoc cref="AcPotential.FromVoltsPeak(double)"/>
+        public static AcPotential VoltsPeak(this double value) => AcPotential.FromVoltsPeak(value);
+
+        /// <inheritdoc cref="AcPotential.FromVoltsPeak(double?)"/>
+        public static AcPotential? VoltsPeak(this double? value) => AcPotential.FromVoltsPeak(value);
+
+        /// <inheritdoc cref="AcPotential.FromVoltsPeak(double)"/>
+        public static AcPotential VoltsPeak(this float value) => AcPotential.FromVoltsPeak(value);
+
+        /// <inheritdoc cref="AcPotential.FromVoltsPeak(double?)"/>
+        public static AcPotential? VoltsPeak(this float? value) => AcPotential.FromVoltsPeak(value);
+
+        /// <inheritdoc cref="AcPotential.FromVoltsPeak(double)"/>
+        public static AcPotential VoltsPeak(this decimal value) => AcPotential.FromVoltsPeak(Convert.ToDouble(value));
+
+        /// <inheritdoc cref="AcPotential.FromVoltsPeak(double?)"/>
+        public static AcPotential? VoltsPeak(this decimal? value) => AcPotential.FromVoltsPeak(value == null ? (double?)null : Convert.ToDouble(value.Value));
+
+        #endregion
+
+        #region VoltPeakToPeak
+
+        /// <inheritdoc cref="AcPotential.FromVoltsPeakToPeak(double)"/>
+        public static AcPotential VoltsPeakToPeak(this int value) => AcPotential.FromVoltsPeakToPeak(value);
+
+        /// <inheritdoc cref="AcPotential.FromVoltsPeakToPeak(double?)"/>
+        public static AcPotential? VoltsPeakToPeak(this int? value) => AcPotential.FromVoltsPeakToPeak(value);
+
+        /// <inheritdoc cref="AcPotential.FromVoltsPeakToPeak(double)"/>
+        public static AcPotential VoltsPeakToPeak(this long value) => AcPotential.FromVoltsPeakToPeak(value);
+
+        /// <inheritdoc cref="AcPotential.FromVoltsPeakToPeak(double?)"/>
+        public static AcPotential? VoltsPeakToPeak(this long? value) => AcPotential.FromVoltsPeakToPeak(value);
+
+        /// <inheritdoc cref="AcPotential.FromVoltsPeakToPeak(double)"/>
+        public static AcPotential VoltsPeakToPeak(this double value) => AcPotential.FromVoltsPeakToPeak(value);
+
+        /// <inheritdoc cref="AcPotential.FromVoltsPeakToPeak(double?)"/>
+        public static AcPotential? VoltsPeakToPeak(this double? value) => AcPotential.FromVoltsPeakToPeak(value);
+
+        /// <inheritdoc cref="AcPotential.FromVoltsPeakToPeak(double)"/>
+        public static AcPotential VoltsPeakToPeak(this float value) => AcPotential.FromVoltsPeakToPeak(value);
+
+        /// <inheritdoc cref="AcPotential.FromVoltsPeakToPeak(double?)"/>
+        public static AcPotential? VoltsPeakToPeak(this float? value) => AcPotential.FromVoltsPeakToPeak(value);
+
+        /// <inheritdoc cref="AcPotential.FromVoltsPeakToPeak(double)"/>
+        public static AcPotential VoltsPeakToPeak(this decimal value) => AcPotential.FromVoltsPeakToPeak(Convert.ToDouble(value));
+
+        /// <inheritdoc cref="AcPotential.FromVoltsPeakToPeak(double?)"/>
+        public static AcPotential? VoltsPeakToPeak(this decimal? value) => AcPotential.FromVoltsPeakToPeak(value == null ? (double?)null : Convert.ToDouble(value.Value));
+
+        #endregion
+
+        #region VoltRMS
+
+        /// <inheritdoc cref="AcPotential.FromVoltsRMS(double)"/>
+        public static AcPotential VoltsRMS(this int value) => AcPotential.FromVoltsRMS(value);
+
+        /// <inheritdoc cref="AcPotential.FromVoltsRMS(double?)"/>
+        public static AcPotential? VoltsRMS(this int? value) => AcPotential.FromVoltsRMS(value);
+
+        /// <inheritdoc cref="AcPotential.FromVoltsRMS(double)"/>
+        public static AcPotential VoltsRMS(this long value) => AcPotential.FromVoltsRMS(value);
+
+        /// <inheritdoc cref="AcPotential.FromVoltsRMS(double?)"/>
+        public static AcPotential? VoltsRMS(this long? value) => AcPotential.FromVoltsRMS(value);
+
+        /// <inheritdoc cref="AcPotential.FromVoltsRMS(double)"/>
+        public static AcPotential VoltsRMS(this double value) => AcPotential.FromVoltsRMS(value);
+
+        /// <inheritdoc cref="AcPotential.FromVoltsRMS(double?)"/>
+        public static AcPotential? VoltsRMS(this double? value) => AcPotential.FromVoltsRMS(value);
+
+        /// <inheritdoc cref="AcPotential.FromVoltsRMS(double)"/>
+        public static AcPotential VoltsRMS(this float value) => AcPotential.FromVoltsRMS(value);
+
+        /// <inheritdoc cref="AcPotential.FromVoltsRMS(double?)"/>
+        public static AcPotential? VoltsRMS(this float? value) => AcPotential.FromVoltsRMS(value);
+
+        /// <inheritdoc cref="AcPotential.FromVoltsRMS(double)"/>
+        public static AcPotential VoltsRMS(this decimal value) => AcPotential.FromVoltsRMS(Convert.ToDouble(value));
+
+        /// <inheritdoc cref="AcPotential.FromVoltsRMS(double?)"/>
+        public static AcPotential? VoltsRMS(this decimal? value) => AcPotential.FromVoltsRMS(value == null ? (double?)null : Convert.ToDouble(value.Value));
+
+        #endregion
+
+    }
+}
+#endif

--- a/UnitsNet/GeneratedCode/UnitClasses/AcPotential.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/AcPotential.g.cs
@@ -38,7 +38,7 @@ using Culture = System.IFormatProvider;
 namespace UnitsNet
 {
     /// <summary>
-    ///     In classical electromagnetism, the electric potential (a scalar quantity denoted by Φ, ΦE or V and also called the electric field potential or the electrostatic potential) at a point is the amount of electric potential energy that a unitary point charge would have when located at that point.
+    ///     A sinusoidally time-varying representation of ElectricPotential.
     /// </summary>
     // ReSharper disable once PartialTypeWithSinglePart
 #if WINDOWS_UWP
@@ -95,7 +95,7 @@ namespace UnitsNet
         }
 
         /// <summary>
-        ///     Get AcPotential in VoltsPeak.
+        ///     Get peak value of AcPotential.
         /// </summary>
         public double VoltsPeak
         {
@@ -103,7 +103,7 @@ namespace UnitsNet
         }
 
         /// <summary>
-        ///     Get AcPotential in VoltsPeakToPeak.
+        ///     Get peak to peak value of AcPotential.
         /// </summary>
         public double VoltsPeakToPeak
         {
@@ -111,7 +111,7 @@ namespace UnitsNet
         }
 
         /// <summary>
-        ///     Get AcPotential in VoltsRMS.
+        ///     Get RMS value of AcPotential.
         /// </summary>
         public double VoltsRMS
         {

--- a/UnitsNet/GeneratedCode/UnitClasses/AcPotential.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/AcPotential.g.cs
@@ -58,9 +58,9 @@ namespace UnitsNet
         }
 #endif
 
-        public AcPotential(double voltsPeak)
+        public AcPotential(double voltspeak)
         {
-          _voltsPeak = Math.Abs(Convert.ToDouble(voltsPeak));
+            _voltsPeak = Convert.ToDouble(voltspeak);
         }
 
         // Method overloads and with same number of parameters not supported in Universal Windows Platform (WinRT Components).
@@ -69,22 +69,21 @@ namespace UnitsNet
 #else
         public
 #endif
-        AcPotential(long voltsPeak)
+        AcPotential(long voltspeak)
         {
-          this._voltsPeak = Math.Abs(Convert.ToDouble(voltsPeak));
+            _voltsPeak = Convert.ToDouble(voltspeak);
         }
 
-
-      // Method overloads and with same number of parameters not supported in Universal Windows Platform (WinRT Components).
+        // Method overloads and with same number of parameters not supported in Universal Windows Platform (WinRT Components).
         // Decimal type not supported in Universal Windows Platform (WinRT Components).
 #if WINDOWS_UWP
         private
 #else
         public
 #endif
-        AcPotential(decimal voltsPeak)
+        AcPotential(decimal voltspeak)
         {
-          _voltsPeak = Math.Abs(Convert.ToDouble(voltsPeak));
+            _voltsPeak = Convert.ToDouble(voltspeak);
         }
 
         #region Properties
@@ -95,27 +94,27 @@ namespace UnitsNet
         }
 
         /// <summary>
-        ///     Get peak value of AcPotential.
+        ///     Get AcPotential in VoltsPeak.
         /// </summary>
         public double VoltsPeak
         {
-            get { return _voltsPeak; }
+            get { return Math.Abs(_voltsPeak); }
         }
 
         /// <summary>
-        ///     Get peak to peak value of AcPotential.
+        ///     Get AcPotential in VoltsPeakToPeak.
         /// </summary>
         public double VoltsPeakToPeak
         {
-            get { return 2*_voltsPeak; }
+            get { return 2*Math.Abs(_voltsPeak); }
         }
 
         /// <summary>
-        ///     Get RMS value of AcPotential.
+        ///     Get AcPotential in VoltsRMS.
         /// </summary>
         public double VoltsRMS
         {
-            get { return _voltsPeak/Math.Sqrt(2); }
+            get { return Math.Abs(_voltsPeak)/Math.Sqrt(2); }
         }
 
         #endregion
@@ -130,9 +129,9 @@ namespace UnitsNet
         /// <summary>
         ///     Get AcPotential from VoltsPeak.
         /// </summary>
-        public static AcPotential FromVoltsPeak(double voltsPeak)
+        public static AcPotential FromVoltsPeak(double voltspeak)
         {
-            return new AcPotential(voltsPeak);
+            return new AcPotential(Math.Abs(voltspeak));
         }
 
         /// <summary>
@@ -140,7 +139,7 @@ namespace UnitsNet
         /// </summary>
         public static AcPotential FromVoltsPeakToPeak(double voltspeaktopeak)
         {
-            return new AcPotential(voltspeaktopeak/2);
+            return new AcPotential(Math.Abs(voltspeaktopeak)/2);
         }
 
         /// <summary>
@@ -148,18 +147,18 @@ namespace UnitsNet
         /// </summary>
         public static AcPotential FromVoltsRMS(double voltsrms)
         {
-            return new AcPotential(Math.Sqrt(2)*voltsrms);
+            return new AcPotential(Math.Sqrt(2)*Math.Abs(voltsrms));
         }
 
 #if !WINDOWS_UWP
         /// <summary>
         ///     Get nullable AcPotential from nullable VoltsPeak.
         /// </summary>
-        public static AcPotential? FromVoltsPeak(double? voltsPeak)
+        public static AcPotential? FromVoltsPeak(double? voltspeak)
         {
-            if (voltsPeak.HasValue)
+            if (voltspeak.HasValue)
             {
-                return FromVoltsPeak(voltsPeak.Value);
+                return FromVoltsPeak(voltspeak.Value);
             }
             else
             {

--- a/UnitsNet/GeneratedCode/UnitClasses/AcPotential.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/AcPotential.g.cs
@@ -1,0 +1,675 @@
+﻿// Copyright Â© 2007 Andreas Gullberg Larsen (anjdreas@gmail.com).
+// https://github.com/anjdreas/UnitsNet
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text.RegularExpressions;
+using System.Linq;
+using JetBrains.Annotations;
+using UnitsNet.Units;
+
+#if WINDOWS_UWP
+using Culture = System.String;
+#else
+using Culture = System.IFormatProvider;
+#endif
+
+// ReSharper disable once CheckNamespace
+
+namespace UnitsNet
+{
+    /// <summary>
+    ///     In classical electromagnetism, the electric potential (a scalar quantity denoted by Φ, ΦE or V and also called the electric field potential or the electrostatic potential) at a point is the amount of electric potential energy that a unitary point charge would have when located at that point.
+    /// </summary>
+    // ReSharper disable once PartialTypeWithSinglePart
+#if WINDOWS_UWP
+    public sealed partial class AcPotential
+#else
+    public partial struct AcPotential : IComparable, IComparable<AcPotential>
+#endif
+    {
+        /// <summary>
+        ///     Base unit of AcPotential.
+        /// </summary>
+        private readonly double _voltsPeak;
+
+#if WINDOWS_UWP
+        public AcPotential() : this(0)
+        {
+        }
+#endif
+
+        public AcPotential(double voltsPeak)
+        {
+          _voltsPeak = Math.Abs(Convert.ToDouble(voltsPeak));
+        }
+
+        // Method overloads and with same number of parameters not supported in Universal Windows Platform (WinRT Components).
+#if WINDOWS_UWP
+        private
+#else
+        public
+#endif
+        AcPotential(long voltsPeak)
+        {
+          this._voltsPeak = Math.Abs(Convert.ToDouble(voltsPeak));
+        }
+
+
+      // Method overloads and with same number of parameters not supported in Universal Windows Platform (WinRT Components).
+        // Decimal type not supported in Universal Windows Platform (WinRT Components).
+#if WINDOWS_UWP
+        private
+#else
+        public
+#endif
+        AcPotential(decimal voltsPeak)
+        {
+          _voltsPeak = Math.Abs(Convert.ToDouble(voltsPeak));
+        }
+
+        #region Properties
+
+        public static AcPotentialUnit BaseUnit
+        {
+            get { return AcPotentialUnit.VoltPeak; }
+        }
+
+        /// <summary>
+        ///     Get AcPotential in VoltsPeak.
+        /// </summary>
+        public double VoltsPeak
+        {
+            get { return _voltsPeak; }
+        }
+
+        /// <summary>
+        ///     Get AcPotential in VoltsPeakToPeak.
+        /// </summary>
+        public double VoltsPeakToPeak
+        {
+            get { return 2*_voltsPeak; }
+        }
+
+        /// <summary>
+        ///     Get AcPotential in VoltsRMS.
+        /// </summary>
+        public double VoltsRMS
+        {
+            get { return _voltsPeak/Math.Sqrt(2); }
+        }
+
+        #endregion
+
+        #region Static
+
+        public static AcPotential Zero
+        {
+            get { return new AcPotential(); }
+        }
+
+        /// <summary>
+        ///     Get AcPotential from VoltsPeak.
+        /// </summary>
+        public static AcPotential FromVoltsPeak(double voltsPeak)
+        {
+            return new AcPotential(voltsPeak);
+        }
+
+        /// <summary>
+        ///     Get AcPotential from VoltsPeakToPeak.
+        /// </summary>
+        public static AcPotential FromVoltsPeakToPeak(double voltspeaktopeak)
+        {
+            return new AcPotential(voltspeaktopeak/2);
+        }
+
+        /// <summary>
+        ///     Get AcPotential from VoltsRMS.
+        /// </summary>
+        public static AcPotential FromVoltsRMS(double voltsrms)
+        {
+            return new AcPotential(Math.Sqrt(2)*voltsrms);
+        }
+
+#if !WINDOWS_UWP
+        /// <summary>
+        ///     Get nullable AcPotential from nullable VoltsPeak.
+        /// </summary>
+        public static AcPotential? FromVoltsPeak(double? voltsPeak)
+        {
+            if (voltsPeak.HasValue)
+            {
+                return FromVoltsPeak(voltsPeak.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
+        ///     Get nullable AcPotential from nullable VoltsPeakToPeak.
+        /// </summary>
+        public static AcPotential? FromVoltsPeakToPeak(double? voltspeaktopeak)
+        {
+            if (voltspeaktopeak.HasValue)
+            {
+                return FromVoltsPeakToPeak(voltspeaktopeak.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
+        ///     Get nullable AcPotential from nullable VoltsRMS.
+        /// </summary>
+        public static AcPotential? FromVoltsRMS(double? voltsrms)
+        {
+            if (voltsrms.HasValue)
+            {
+                return FromVoltsRMS(voltsrms.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+#endif
+
+        /// <summary>
+        ///     Dynamically convert from value and unit enum <see cref="AcPotentialUnit" /> to <see cref="AcPotential" />.
+        /// </summary>
+        /// <param name="val">Value to convert from.</param>
+        /// <param name="fromUnit">Unit to convert from.</param>
+        /// <returns>AcPotential unit value.</returns>
+        public static AcPotential From(double val, AcPotentialUnit fromUnit)
+        {
+            switch (fromUnit)
+            {
+                case AcPotentialUnit.VoltPeak:
+                    return FromVoltsPeak(val);
+                case AcPotentialUnit.VoltPeakToPeak:
+                    return FromVoltsPeakToPeak(val);
+                case AcPotentialUnit.VoltRMS:
+                    return FromVoltsRMS(val);
+
+                default:
+                    throw new NotImplementedException("fromUnit: " + fromUnit);
+            }
+        }
+
+#if !WINDOWS_UWP
+        /// <summary>
+        ///     Dynamically convert from value and unit enum <see cref="AcPotentialUnit" /> to <see cref="AcPotential" />.
+        /// </summary>
+        /// <param name="value">Value to convert from.</param>
+        /// <param name="fromUnit">Unit to convert from.</param>
+        /// <returns>AcPotential unit value.</returns>
+        public static AcPotential? From(double? value, AcPotentialUnit fromUnit)
+        {
+            if (!value.HasValue)
+            {
+                return null;
+            }
+            switch (fromUnit)
+            {
+                case AcPotentialUnit.VoltPeak:
+                    return FromVoltsPeak(value.Value);
+                case AcPotentialUnit.VoltPeakToPeak:
+                    return FromVoltsPeakToPeak(value.Value);
+                case AcPotentialUnit.VoltRMS:
+                    return FromVoltsRMS(value.Value);
+
+                default:
+                    throw new NotImplementedException("fromUnit: " + fromUnit);
+            }
+        }
+#endif
+
+        /// <summary>
+        ///     Get unit abbreviation string.
+        /// </summary>
+        /// <param name="unit">Unit to get abbreviation for.</param>
+        /// <returns>Unit abbreviation string.</returns>
+        [UsedImplicitly]
+        public static string GetAbbreviation(AcPotentialUnit unit)
+        {
+            return GetAbbreviation(unit, null);
+        }
+
+        /// <summary>
+        ///     Get unit abbreviation string.
+        /// </summary>
+        /// <param name="unit">Unit to get abbreviation for.</param>
+        /// <param name="culture">Culture to use for localization. Defaults to Thread.CurrentUICulture.</param>
+        /// <returns>Unit abbreviation string.</returns>
+        [UsedImplicitly]
+        public static string GetAbbreviation(AcPotentialUnit unit, [CanBeNull] Culture culture)
+        {
+            return UnitSystem.GetCached(culture).GetDefaultAbbreviation(unit);
+        }
+
+        #endregion
+
+        #region Arithmetic Operators
+
+#if !WINDOWS_UWP
+        public static AcPotential operator -(AcPotential right)
+        {
+            return new AcPotential(-right._voltsPeak);
+        }
+
+        public static AcPotential operator +(AcPotential left, AcPotential right)
+        {
+            return new AcPotential(left._voltsPeak + right._voltsPeak);
+        }
+
+        public static AcPotential operator -(AcPotential left, AcPotential right)
+        {
+            return new AcPotential(left._voltsPeak - right._voltsPeak);
+        }
+
+        public static AcPotential operator *(double left, AcPotential right)
+        {
+            return new AcPotential(left*right._voltsPeak);
+        }
+
+        public static AcPotential operator *(AcPotential left, double right)
+        {
+            return new AcPotential(left._voltsPeak*(double)right);
+        }
+
+        public static AcPotential operator /(AcPotential left, double right)
+        {
+            return new AcPotential(left._voltsPeak/(double)right);
+        }
+
+        public static double operator /(AcPotential left, AcPotential right)
+        {
+            return Convert.ToDouble(left._voltsPeak/right._voltsPeak);
+        }
+#endif
+
+        #endregion
+
+        #region Equality / IComparable
+
+        public int CompareTo(object obj)
+        {
+            if (obj == null) throw new ArgumentNullException("obj");
+            if (!(obj is AcPotential)) throw new ArgumentException("Expected type AcPotential.", "obj");
+            return CompareTo((AcPotential) obj);
+        }
+
+#if WINDOWS_UWP
+        internal
+#else
+        public
+#endif
+        int CompareTo(AcPotential other)
+        {
+            return _voltsPeak.CompareTo(other._voltsPeak);
+        }
+
+#if !WINDOWS_UWP
+        public static bool operator <=(AcPotential left, AcPotential right)
+        {
+            return left._voltsPeak <= right._voltsPeak;
+        }
+
+        public static bool operator >=(AcPotential left, AcPotential right)
+        {
+            return left._voltsPeak >= right._voltsPeak;
+        }
+
+        public static bool operator <(AcPotential left, AcPotential right)
+        {
+            return left._voltsPeak < right._voltsPeak;
+        }
+
+        public static bool operator >(AcPotential left, AcPotential right)
+        {
+            return left._voltsPeak > right._voltsPeak;
+        }
+
+        public static bool operator ==(AcPotential left, AcPotential right)
+        {
+            // ReSharper disable once CompareOfFloatsByEqualityOperator
+            return left._voltsPeak == right._voltsPeak;
+        }
+
+        public static bool operator !=(AcPotential left, AcPotential right)
+        {
+            // ReSharper disable once CompareOfFloatsByEqualityOperator
+            return left._voltsPeak != right._voltsPeak;
+        }
+#endif
+
+        public override bool Equals(object obj)
+        {
+            if (obj == null || GetType() != obj.GetType())
+            {
+                return false;
+            }
+
+            return _voltsPeak.Equals(((AcPotential) obj)._voltsPeak);
+        }
+
+        public override int GetHashCode()
+        {
+            return _voltsPeak.GetHashCode();
+        }
+
+        #endregion
+
+        #region Conversion
+
+        /// <summary>
+        ///     Convert to the unit representation <paramref name="unit" />.
+        /// </summary>
+        /// <returns>Value in new unit if successful, exception otherwise.</returns>
+        /// <exception cref="NotImplementedException">If conversion was not successful.</exception>
+        public double As(AcPotentialUnit unit)
+        {
+            switch (unit)
+            {
+                case AcPotentialUnit.VoltPeak:
+                    return VoltsPeak;
+                case AcPotentialUnit.VoltPeakToPeak:
+                    return VoltsPeakToPeak;
+                case AcPotentialUnit.VoltRMS:
+                    return VoltsRMS;
+
+                default:
+                    throw new NotImplementedException("unit: " + unit);
+            }
+        }
+
+        #endregion
+
+        #region Parsing
+
+        /// <summary>
+        ///     Parse a string with one or two quantities of the format "&lt;quantity&gt; &lt;unit&gt;".
+        /// </summary>
+        /// <param name="str">String to parse. Typically in the form: {number} {unit}</param>
+        /// <example>
+        ///     Length.Parse("5.5 m", new CultureInfo("en-US"));
+        /// </example>
+        /// <exception cref="ArgumentNullException">The value of 'str' cannot be null. </exception>
+        /// <exception cref="ArgumentException">
+        ///     Expected string to have one or two pairs of quantity and unit in the format
+        ///     "&lt;quantity&gt; &lt;unit&gt;". Eg. "5.5 m" or "1ft 2in"
+        /// </exception>
+        /// <exception cref="AmbiguousUnitParseException">
+        ///     More than one unit is represented by the specified unit abbreviation.
+        ///     Example: Volume.Parse("1 cup") will throw, because it can refer to any of
+        ///     <see cref="VolumeUnit.MetricCup" />, <see cref="VolumeUnit.UsLegalCup" /> and <see cref="VolumeUnit.UsCustomaryCup" />.
+        /// </exception>
+        /// <exception cref="UnitsNetException">
+        ///     If anything else goes wrong, typically due to a bug or unhandled case.
+        ///     We wrap exceptions in <see cref="UnitsNetException" /> to allow you to distinguish
+        ///     Units.NET exceptions from other exceptions.
+        /// </exception>
+        public static AcPotential Parse(string str)
+        {
+            return Parse(str, null);
+        }
+
+        /// <summary>
+        ///     Parse a string with one or two quantities of the format "&lt;quantity&gt; &lt;unit&gt;".
+        /// </summary>
+        /// <param name="str">String to parse. Typically in the form: {number} {unit}</param>
+        /// <param name="culture">Format to use when parsing number and unit. If it is null, it defaults to <see cref="NumberFormatInfo.CurrentInfo"/> for parsing the number and <see cref="CultureInfo.CurrentUICulture"/> for parsing the unit abbreviation by culture/language.</param>
+        /// <example>
+        ///     Length.Parse("5.5 m", new CultureInfo("en-US"));
+        /// </example>
+        /// <exception cref="ArgumentNullException">The value of 'str' cannot be null. </exception>
+        /// <exception cref="ArgumentException">
+        ///     Expected string to have one or two pairs of quantity and unit in the format
+        ///     "&lt;quantity&gt; &lt;unit&gt;". Eg. "5.5 m" or "1ft 2in"
+        /// </exception>
+        /// <exception cref="AmbiguousUnitParseException">
+        ///     More than one unit is represented by the specified unit abbreviation.
+        ///     Example: Volume.Parse("1 cup") will throw, because it can refer to any of
+        ///     <see cref="VolumeUnit.MetricCup" />, <see cref="VolumeUnit.UsLegalCup" /> and <see cref="VolumeUnit.UsCustomaryCup" />.
+        /// </exception>
+        /// <exception cref="UnitsNetException">
+        ///     If anything else goes wrong, typically due to a bug or unhandled case.
+        ///     We wrap exceptions in <see cref="UnitsNetException" /> to allow you to distinguish
+        ///     Units.NET exceptions from other exceptions.
+        /// </exception>
+        public static AcPotential Parse(string str, [CanBeNull] Culture culture)
+        {
+            if (str == null) throw new ArgumentNullException("str");
+
+#if WINDOWS_UWP
+            IFormatProvider formatProvider = culture == null ? null : new CultureInfo(culture);
+#else
+            IFormatProvider formatProvider = culture;
+#endif
+            return UnitParser.ParseUnit<AcPotential>(str, formatProvider,
+                delegate(string value, string unit, IFormatProvider formatProvider2)
+                {
+                    double parsedValue = double.Parse(value, formatProvider2);
+                    AcPotentialUnit parsedUnit = ParseUnit(unit, formatProvider2);
+                    return From(parsedValue, parsedUnit);
+                }, (x, y) => FromVoltsPeak(x.VoltsPeak + y.VoltsPeak));
+        }
+
+        /// <summary>
+        ///     Try to parse a string with one or two quantities of the format "&lt;quantity&gt; &lt;unit&gt;".
+        /// </summary>
+        /// <param name="str">String to parse. Typically in the form: {number} {unit}</param>
+        /// <param name="result">Resulting unit quantity if successful.</param>
+        /// <example>
+        ///     Length.Parse("5.5 m", new CultureInfo("en-US"));
+        /// </example>
+        public static bool TryParse([CanBeNull] string str, out AcPotential result)
+        {
+            return TryParse(str, null, out result);
+        }
+
+        /// <summary>
+        ///     Try to parse a string with one or two quantities of the format "&lt;quantity&gt; &lt;unit&gt;".
+        /// </summary>
+        /// <param name="str">String to parse. Typically in the form: {number} {unit}</param>
+        /// <param name="culture">Format to use when parsing number and unit. If it is null, it defaults to <see cref="NumberFormatInfo.CurrentInfo"/> for parsing the number and <see cref="CultureInfo.CurrentUICulture"/> for parsing the unit abbreviation by culture/language.</param>
+        /// <param name="result">Resulting unit quantity if successful.</param>
+        /// <example>
+        ///     Length.Parse("5.5 m", new CultureInfo("en-US"));
+        /// </example>
+        public static bool TryParse([CanBeNull] string str, [CanBeNull] Culture culture, out AcPotential result)
+        {
+            try
+            {
+                result = Parse(str, culture);
+                return true;
+            }
+            catch
+            {
+                result = default(AcPotential);
+                return false;
+            }
+        }
+
+        /// <summary>
+        ///     Parse a unit string.
+        /// </summary>
+        /// <example>
+        ///     Length.ParseUnit("m", new CultureInfo("en-US"));
+        /// </example>
+        /// <exception cref="ArgumentNullException">The value of 'str' cannot be null. </exception>
+        /// <exception cref="UnitsNetException">Error parsing string.</exception>
+        public static AcPotentialUnit ParseUnit(string str)
+        {
+            return ParseUnit(str, (IFormatProvider)null);
+        }
+
+        /// <summary>
+        ///     Parse a unit string.
+        /// </summary>
+        /// <example>
+        ///     Length.ParseUnit("m", new CultureInfo("en-US"));
+        /// </example>
+        /// <exception cref="ArgumentNullException">The value of 'str' cannot be null. </exception>
+        /// <exception cref="UnitsNetException">Error parsing string.</exception>
+        public static AcPotentialUnit ParseUnit(string str, [CanBeNull] string cultureName)
+        {
+            return ParseUnit(str, cultureName == null ? null : new CultureInfo(cultureName));
+        }
+
+        /// <summary>
+        ///     Parse a unit string.
+        /// </summary>
+        /// <example>
+        ///     Length.ParseUnit("m", new CultureInfo("en-US"));
+        /// </example>
+        /// <exception cref="ArgumentNullException">The value of 'str' cannot be null. </exception>
+        /// <exception cref="UnitsNetException">Error parsing string.</exception>
+#if WINDOWS_UWP
+        internal
+#else
+        public
+#endif
+        static AcPotentialUnit ParseUnit(string str, IFormatProvider formatProvider = null)
+        {
+            if (str == null) throw new ArgumentNullException("str");
+
+            var unitSystem = UnitSystem.GetCached(formatProvider);
+            var unit = unitSystem.Parse<AcPotentialUnit>(str.Trim());
+
+            if (unit == AcPotentialUnit.Undefined)
+            {
+                var newEx = new UnitsNetException("Error parsing string. The unit is not a recognized AcPotentialUnit.");
+                newEx.Data["input"] = str;
+                newEx.Data["formatprovider"] = formatProvider?.ToString() ?? "(null)";
+                throw newEx;
+            }
+
+            return unit;
+        }
+
+        #endregion
+
+        /// <summary>
+        ///     Set the default unit used by ToString(). Default is VoltPeak
+        /// </summary>
+        public static AcPotentialUnit ToStringDefaultUnit { get; set; } = AcPotentialUnit.VoltPeak;
+
+        /// <summary>
+        ///     Get default string representation of value and unit.
+        /// </summary>
+        /// <returns>String representation.</returns>
+        public override string ToString()
+        {
+            return ToString(ToStringDefaultUnit);
+        }
+
+        /// <summary>
+        ///     Get string representation of value and unit. Using current UI culture and two significant digits after radix.
+        /// </summary>
+        /// <param name="unit">Unit representation to use.</param>
+        /// <returns>String representation.</returns>
+        public string ToString(AcPotentialUnit unit)
+        {
+            return ToString(unit, null, 2);
+        }
+
+        /// <summary>
+        ///     Get string representation of value and unit. Using two significant digits after radix.
+        /// </summary>
+        /// <param name="unit">Unit representation to use.</param>
+        /// <param name="culture">Culture to use for localization and number formatting.</param>
+        /// <returns>String representation.</returns>
+        public string ToString(AcPotentialUnit unit, [CanBeNull] Culture culture)
+        {
+            return ToString(unit, culture, 2);
+        }
+
+        /// <summary>
+        ///     Get string representation of value and unit.
+        /// </summary>
+        /// <param name="unit">Unit representation to use.</param>
+        /// <param name="culture">Culture to use for localization and number formatting.</param>
+        /// <param name="significantDigitsAfterRadix">The number of significant digits after the radix point.</param>
+        /// <returns>String representation.</returns>
+        [UsedImplicitly]
+        public string ToString(AcPotentialUnit unit, [CanBeNull] Culture culture, int significantDigitsAfterRadix)
+        {
+            double value = As(unit);
+            string format = UnitFormatter.GetFormat(value, significantDigitsAfterRadix);
+            return ToString(unit, culture, format);
+        }
+
+        /// <summary>
+        ///     Get string representation of value and unit.
+        /// </summary>
+        /// <param name="culture">Culture to use for localization and number formatting.</param>
+        /// <param name="unit">Unit representation to use.</param>
+        /// <param name="format">String format to use. Default:  "{0:0.##} {1} for value and unit abbreviation respectively."</param>
+        /// <param name="args">Arguments for string format. Value and unit are implictly included as arguments 0 and 1.</param>
+        /// <returns>String representation.</returns>
+        [UsedImplicitly]
+        public string ToString(AcPotentialUnit unit, [CanBeNull] Culture culture, [NotNull] string format,
+            [NotNull] params object[] args)
+        {
+            if (format == null) throw new ArgumentNullException(nameof(format));
+            if (args == null) throw new ArgumentNullException(nameof(args));
+
+#if WINDOWS_UWP
+            IFormatProvider formatProvider = culture == null ? null : new CultureInfo(culture);
+#else
+            IFormatProvider formatProvider = culture;
+#endif
+            double value = As(unit);
+            object[] formatArgs = UnitFormatter.GetFormatArgs(unit, value, formatProvider, args);
+            return string.Format(formatProvider, format, formatArgs);
+        }
+
+        /// <summary>
+        /// Represents the largest possible value of AcPotential
+        /// </summary>
+        public static AcPotential MaxValue
+        {
+            get
+            {
+                return new AcPotential(double.MaxValue);
+            }
+        }
+
+        /// <summary>
+        /// Represents the smallest possible value of AcPotential
+        /// </summary>
+        public static AcPotential MinValue
+        {
+            get
+            {
+                return new AcPotential(double.MinValue);
+            }
+        }
+    }
+}

--- a/UnitsNet/GeneratedCode/UnitSystem.Default.g.cs
+++ b/UnitsNet/GeneratedCode/UnitSystem.Default.g.cs
@@ -73,6 +73,25 @@ namespace UnitsNet
                                 new AbbreviationsForCulture("en-US", "nm/s²"),
                             }),
                     }),
+                new UnitLocalization(typeof (AcPotentialUnit),
+                    new[]
+                    {
+                        new CulturesForEnumValue((int) AcPotentialUnit.VoltPeak,
+                            new[]
+                            {
+                                new AbbreviationsForCulture("en-US", "Vp"),
+                            }),
+                        new CulturesForEnumValue((int) AcPotentialUnit.VoltPeakToPeak,
+                            new[]
+                            {
+                                new AbbreviationsForCulture("en-US", "Vpp"),
+                            }),
+                        new CulturesForEnumValue((int) AcPotentialUnit.VoltRMS,
+                            new[]
+                            {
+                                new AbbreviationsForCulture("en-US", "Vrms"),
+                            }),
+                    }),
                 new UnitLocalization(typeof (AmplitudeRatioUnit),
                     new[]
                     {

--- a/UnitsNet/Scripts/UnitDefinitions/AcPotential.json
+++ b/UnitsNet/Scripts/UnitDefinitions/AcPotential.json
@@ -1,0 +1,43 @@
+﻿{
+  "Name": "AcPotential",
+  "BaseUnit": "VoltPeak",
+  "XmlDoc": "In classical electromagnetism, the electric potential (a scalar quantity denoted by Φ, ΦE or V and also called the electric field potential or the electrostatic potential) at a point is the amount of electric potential energy that a unitary point charge would have when located at that point.",
+  "Units": [
+     {
+      "SingularName": "VoltPeak",
+      "PluralName": "VoltsPeak",
+      "FromUnitToBaseFunc": "x",
+      "FromBaseToUnitFunc": "x",
+      "Localization": [
+        {
+          "Culture": "en-US",
+          "Abbreviations": [ "Vp" ]
+        }
+      ]
+    },
+    {
+      "SingularName": "VoltPeakToPeak",
+      "PluralName": "VoltsPeakToPeak",
+      "FromUnitToBaseFunc": "x/2",
+      "FromBaseToUnitFunc": "2*x",
+      "Localization": [
+        {
+          "Culture": "en-US",
+          "Abbreviations": [ "Vpp" ]
+        }
+      ]
+    },
+    {
+      "SingularName": "VoltRMS",
+      "PluralName": "VoltsRMS",
+      "FromUnitToBaseFunc": "Math.Sqrt(2)*x",
+      "FromBaseToUnitFunc": "x/Math.Sqrt(2)",
+      "Localization": [
+        {
+          "Culture": "en-US",
+          "Abbreviations": [ "Vrms" ]
+        }
+      ]
+    }
+  ]
+}

--- a/UnitsNet/Scripts/UnitDefinitions/AcPotential.json
+++ b/UnitsNet/Scripts/UnitDefinitions/AcPotential.json
@@ -1,13 +1,13 @@
 ﻿{
   "Name": "AcPotential",
   "BaseUnit": "VoltPeak",
-  "XmlDoc": "In classical electromagnetism, the electric potential (a scalar quantity denoted by Φ, ΦE or V and also called the electric field potential or the electrostatic potential) at a point is the amount of electric potential energy that a unitary point charge would have when located at that point.",
+  "XmlDoc": "A sinusoidally time-varying representation of ElectricPotential.",
   "Units": [
      {
       "SingularName": "VoltPeak",
       "PluralName": "VoltsPeak",
-      "FromUnitToBaseFunc": "x",
-      "FromBaseToUnitFunc": "x",
+      "FromUnitToBaseFunc": "Math.Abs(x)",
+      "FromBaseToUnitFunc": "Math.Abs(x)",
       "Localization": [
         {
           "Culture": "en-US",
@@ -18,8 +18,8 @@
     {
       "SingularName": "VoltPeakToPeak",
       "PluralName": "VoltsPeakToPeak",
-      "FromUnitToBaseFunc": "x/2",
-      "FromBaseToUnitFunc": "2*x",
+      "FromUnitToBaseFunc": "Math.Abs(x)/2",
+      "FromBaseToUnitFunc": "2*Math.Abs(x)",
       "Localization": [
         {
           "Culture": "en-US",
@@ -30,8 +30,8 @@
     {
       "SingularName": "VoltRMS",
       "PluralName": "VoltsRMS",
-      "FromUnitToBaseFunc": "Math.Sqrt(2)*x",
-      "FromBaseToUnitFunc": "x/Math.Sqrt(2)",
+      "FromUnitToBaseFunc": "Math.Sqrt(2)*Math.Abs(x)",
+      "FromBaseToUnitFunc": "Math.Abs(x)/Math.Sqrt(2)",
       "Localization": [
         {
           "Culture": "en-US",


### PR DESCRIPTION
I need to represent electrical signals in such a way that I can quickly determine their peak, peak to peak, and RMS values quickly. Integration with AmplitudeRatio is crutial. Assumes signal is a sinusoid.

I didn't believe it was appropriate to extend ElectricPotential since further development (aka adding a Frequency property) would muddy the intent of ElectricPotential. So far EP feels very much like a DC representation of the same.

It could be argued that DC potential is a special case of AC, however that requires polymorphic RMS calculations and is honestly overkill for what I need at the moment.
