### PR TITLE
Added DecibelsUnloaded (dBu) to AmplitudeRatio

### DIFF
--- a/UnitsNet.Tests/CustomCode/AmplitudeRatioTests.cs
+++ b/UnitsNet.Tests/CustomCode/AmplitudeRatioTests.cs
@@ -31,6 +31,8 @@ namespace UnitsNet.Tests.CustomCode
 
         protected override double DecibelMillivoltsInOneDecibelVolt => 61;
 
+        protected override double DecibelsUnloadedInOneDecibelVolt => 3.218487499;
+
         protected override double DecibelVoltsInOneDecibelVolt => 1;
 
         protected override void AssertLogarithmicAddition()

--- a/UnitsNet.Tests/GeneratedCode/AmplitudeRatioTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/AmplitudeRatioTestsBase.g.cs
@@ -38,11 +38,13 @@ namespace UnitsNet.Tests
     {
         protected abstract double DecibelMicrovoltsInOneDecibelVolt { get; }
         protected abstract double DecibelMillivoltsInOneDecibelVolt { get; }
+        protected abstract double DecibelsUnloadedInOneDecibelVolt { get; }
         protected abstract double DecibelVoltsInOneDecibelVolt { get; }
 
 // ReSharper disable VirtualMemberNeverOverriden.Global
         protected virtual double DecibelMicrovoltsTolerance { get { return 1e-5; } }
         protected virtual double DecibelMillivoltsTolerance { get { return 1e-5; } }
+        protected virtual double DecibelsUnloadedTolerance { get { return 1e-5; } }
         protected virtual double DecibelVoltsTolerance { get { return 1e-5; } }
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
@@ -52,6 +54,7 @@ namespace UnitsNet.Tests
             AmplitudeRatio decibelvolt = AmplitudeRatio.FromDecibelVolts(1);
             Assert.AreEqual(DecibelMicrovoltsInOneDecibelVolt, decibelvolt.DecibelMicrovolts, DecibelMicrovoltsTolerance);
             Assert.AreEqual(DecibelMillivoltsInOneDecibelVolt, decibelvolt.DecibelMillivolts, DecibelMillivoltsTolerance);
+            Assert.AreEqual(DecibelsUnloadedInOneDecibelVolt, decibelvolt.DecibelsUnloaded, DecibelsUnloadedTolerance);
             Assert.AreEqual(DecibelVoltsInOneDecibelVolt, decibelvolt.DecibelVolts, DecibelVoltsTolerance);
         }
 
@@ -60,6 +63,7 @@ namespace UnitsNet.Tests
         {
             Assert.AreEqual(1, AmplitudeRatio.From(1, AmplitudeRatioUnit.DecibelMicrovolt).DecibelMicrovolts, DecibelMicrovoltsTolerance);
             Assert.AreEqual(1, AmplitudeRatio.From(1, AmplitudeRatioUnit.DecibelMillivolt).DecibelMillivolts, DecibelMillivoltsTolerance);
+            Assert.AreEqual(1, AmplitudeRatio.From(1, AmplitudeRatioUnit.DecibelUnloaded).DecibelsUnloaded, DecibelsUnloadedTolerance);
             Assert.AreEqual(1, AmplitudeRatio.From(1, AmplitudeRatioUnit.DecibelVolt).DecibelVolts, DecibelVoltsTolerance);
         }
 
@@ -69,6 +73,7 @@ namespace UnitsNet.Tests
             var decibelvolt = AmplitudeRatio.FromDecibelVolts(1);
             Assert.AreEqual(DecibelMicrovoltsInOneDecibelVolt, decibelvolt.As(AmplitudeRatioUnit.DecibelMicrovolt), DecibelMicrovoltsTolerance);
             Assert.AreEqual(DecibelMillivoltsInOneDecibelVolt, decibelvolt.As(AmplitudeRatioUnit.DecibelMillivolt), DecibelMillivoltsTolerance);
+            Assert.AreEqual(DecibelsUnloadedInOneDecibelVolt, decibelvolt.As(AmplitudeRatioUnit.DecibelUnloaded), DecibelsUnloadedTolerance);
             Assert.AreEqual(DecibelVoltsInOneDecibelVolt, decibelvolt.As(AmplitudeRatioUnit.DecibelVolt), DecibelVoltsTolerance);
         }
 
@@ -78,6 +83,7 @@ namespace UnitsNet.Tests
             AmplitudeRatio decibelvolt = AmplitudeRatio.FromDecibelVolts(1);
             Assert.AreEqual(1, AmplitudeRatio.FromDecibelMicrovolts(decibelvolt.DecibelMicrovolts).DecibelVolts, DecibelMicrovoltsTolerance);
             Assert.AreEqual(1, AmplitudeRatio.FromDecibelMillivolts(decibelvolt.DecibelMillivolts).DecibelVolts, DecibelMillivoltsTolerance);
+            Assert.AreEqual(1, AmplitudeRatio.FromDecibelsUnloaded(decibelvolt.DecibelsUnloaded).DecibelVolts, DecibelsUnloadedTolerance);
             Assert.AreEqual(1, AmplitudeRatio.FromDecibelVolts(decibelvolt.DecibelVolts).DecibelVolts, DecibelVoltsTolerance);
         }
 

--- a/UnitsNet/GeneratedCode/Enums/AmplitudeRatioUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Enums/AmplitudeRatioUnit.g.cs
@@ -27,6 +27,7 @@ namespace UnitsNet.Units
         Undefined = 0,
         DecibelMicrovolt,
         DecibelMillivolt,
+        DecibelUnloaded,
         DecibelVolt,
     }
 }

--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToAmplitudeRatioExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToAmplitudeRatioExtensions.g.cs
@@ -95,6 +95,40 @@ namespace UnitsNet.Extensions.NumberToAmplitudeRatio
 
         #endregion
 
+        #region DecibelUnloaded
+
+        /// <inheritdoc cref="AmplitudeRatio.FromDecibelsUnloaded(double)"/>
+        public static AmplitudeRatio DecibelsUnloaded(this int value) => AmplitudeRatio.FromDecibelsUnloaded(value);
+
+        /// <inheritdoc cref="AmplitudeRatio.FromDecibelsUnloaded(double?)"/>
+        public static AmplitudeRatio? DecibelsUnloaded(this int? value) => AmplitudeRatio.FromDecibelsUnloaded(value);
+
+        /// <inheritdoc cref="AmplitudeRatio.FromDecibelsUnloaded(double)"/>
+        public static AmplitudeRatio DecibelsUnloaded(this long value) => AmplitudeRatio.FromDecibelsUnloaded(value);
+
+        /// <inheritdoc cref="AmplitudeRatio.FromDecibelsUnloaded(double?)"/>
+        public static AmplitudeRatio? DecibelsUnloaded(this long? value) => AmplitudeRatio.FromDecibelsUnloaded(value);
+
+        /// <inheritdoc cref="AmplitudeRatio.FromDecibelsUnloaded(double)"/>
+        public static AmplitudeRatio DecibelsUnloaded(this double value) => AmplitudeRatio.FromDecibelsUnloaded(value);
+
+        /// <inheritdoc cref="AmplitudeRatio.FromDecibelsUnloaded(double?)"/>
+        public static AmplitudeRatio? DecibelsUnloaded(this double? value) => AmplitudeRatio.FromDecibelsUnloaded(value);
+
+        /// <inheritdoc cref="AmplitudeRatio.FromDecibelsUnloaded(double)"/>
+        public static AmplitudeRatio DecibelsUnloaded(this float value) => AmplitudeRatio.FromDecibelsUnloaded(value);
+
+        /// <inheritdoc cref="AmplitudeRatio.FromDecibelsUnloaded(double?)"/>
+        public static AmplitudeRatio? DecibelsUnloaded(this float? value) => AmplitudeRatio.FromDecibelsUnloaded(value);
+
+        /// <inheritdoc cref="AmplitudeRatio.FromDecibelsUnloaded(double)"/>
+        public static AmplitudeRatio DecibelsUnloaded(this decimal value) => AmplitudeRatio.FromDecibelsUnloaded(Convert.ToDouble(value));
+
+        /// <inheritdoc cref="AmplitudeRatio.FromDecibelsUnloaded(double?)"/>
+        public static AmplitudeRatio? DecibelsUnloaded(this decimal? value) => AmplitudeRatio.FromDecibelsUnloaded(value == null ? (double?)null : Convert.ToDouble(value.Value));
+
+        #endregion
+
         #region DecibelVolt
 
         /// <inheritdoc cref="AmplitudeRatio.FromDecibelVolts(double)"/>

--- a/UnitsNet/GeneratedCode/UnitClasses/AmplitudeRatio.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/AmplitudeRatio.g.cs
@@ -110,6 +110,14 @@ namespace UnitsNet
         }
 
         /// <summary>
+        ///     Get AmplitudeRatio in DecibelsUnloaded.
+        /// </summary>
+        public double DecibelsUnloaded
+        {
+            get { return _decibelVolts + 2.218487499; }
+        }
+
+        /// <summary>
         ///     Get AmplitudeRatio in DecibelVolts.
         /// </summary>
         public double DecibelVolts
@@ -140,6 +148,14 @@ namespace UnitsNet
         public static AmplitudeRatio FromDecibelMillivolts(double decibelmillivolts)
         {
             return new AmplitudeRatio(decibelmillivolts - 60);
+        }
+
+        /// <summary>
+        ///     Get AmplitudeRatio from DecibelsUnloaded.
+        /// </summary>
+        public static AmplitudeRatio FromDecibelsUnloaded(double decibelsunloaded)
+        {
+            return new AmplitudeRatio(decibelsunloaded - 2.218487499);
         }
 
         /// <summary>
@@ -182,6 +198,21 @@ namespace UnitsNet
         }
 
         /// <summary>
+        ///     Get nullable AmplitudeRatio from nullable DecibelsUnloaded.
+        /// </summary>
+        public static AmplitudeRatio? FromDecibelsUnloaded(double? decibelsunloaded)
+        {
+            if (decibelsunloaded.HasValue)
+            {
+                return FromDecibelsUnloaded(decibelsunloaded.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
         ///     Get nullable AmplitudeRatio from nullable DecibelVolts.
         /// </summary>
         public static AmplitudeRatio? FromDecibelVolts(double? decibelvolts)
@@ -212,6 +243,8 @@ namespace UnitsNet
                     return FromDecibelMicrovolts(val);
                 case AmplitudeRatioUnit.DecibelMillivolt:
                     return FromDecibelMillivolts(val);
+                case AmplitudeRatioUnit.DecibelUnloaded:
+                    return FromDecibelsUnloaded(val);
                 case AmplitudeRatioUnit.DecibelVolt:
                     return FromDecibelVolts(val);
 
@@ -239,6 +272,8 @@ namespace UnitsNet
                     return FromDecibelMicrovolts(value.Value);
                 case AmplitudeRatioUnit.DecibelMillivolt:
                     return FromDecibelMillivolts(value.Value);
+                case AmplitudeRatioUnit.DecibelUnloaded:
+                    return FromDecibelsUnloaded(value.Value);
                 case AmplitudeRatioUnit.DecibelVolt:
                     return FromDecibelVolts(value.Value);
 
@@ -407,6 +442,8 @@ namespace UnitsNet
                     return DecibelMicrovolts;
                 case AmplitudeRatioUnit.DecibelMillivolt:
                     return DecibelMillivolts;
+                case AmplitudeRatioUnit.DecibelUnloaded:
+                    return DecibelsUnloaded;
                 case AmplitudeRatioUnit.DecibelVolt:
                     return DecibelVolts;
 

--- a/UnitsNet/GeneratedCode/UnitSystem.Default.g.cs
+++ b/UnitsNet/GeneratedCode/UnitSystem.Default.g.cs
@@ -86,6 +86,11 @@ namespace UnitsNet
                             {
                                 new AbbreviationsForCulture("en-US", "dBmV"),
                             }),
+                        new CulturesForEnumValue((int) AmplitudeRatioUnit.DecibelUnloaded,
+                            new[]
+                            {
+                                new AbbreviationsForCulture("en-US", "dBu"),
+                            }),
                         new CulturesForEnumValue((int) AmplitudeRatioUnit.DecibelVolt,
                             new[]
                             {

--- a/UnitsNet/Scripts/UnitDefinitions/AmplitudeRatio.json
+++ b/UnitsNet/Scripts/UnitDefinitions/AmplitudeRatio.json
@@ -40,6 +40,18 @@
           "Abbreviations": [ "dBmV" ]
         }
       ]
+    },
+    {
+    "SingularName": "DecibelUnloaded",
+    "PluralName": "DecibelsUnloaded",
+    "FromUnitToBaseFunc": "x - 2.218487499",
+    "FromBaseToUnitFunc": "x + 2.218487499",
+    "Localization": [
+        {
+          "Culture": "en-US",
+          "Abbreviations": [ "dBu" ]
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
dBV is useful for signal level in consumer electronics, but dBu is the preferred unit in pro audio applications.

This PR adds a dBu unit to the AmplitudeRatio struct.