### PR TITLE
Modified serilization to support units saved as IComparable

### DIFF
--- a/UnitsNet.Serialization.JsonNet.Tests/UnitsNetJsonConverterTests.cs
+++ b/UnitsNet.Serialization.JsonNet.Tests/UnitsNetJsonConverterTests.cs
@@ -235,9 +235,9 @@ namespace UnitsNet.Serialization.JsonNet.Tests
                 {
                     Value = Power.FromWatts(10)
                 };
-                JsonSerializerSettings jsonSerializerSettings = CreateJsonSerializerSettigns();
+                JsonSerializerSettings jsonSerializerSettings = CreateJsonSerializerSettings();
 
-                string json = JsonConvert.SerializeObject(testObjWithIComparable,jsonSerializerSettings);
+                string json = JsonConvert.SerializeObject(testObjWithIComparable, jsonSerializerSettings);
 
                 var deserializedTestObject = JsonConvert.DeserializeObject<TestObjWithIComparable>(json,jsonSerializerSettings);
                
@@ -252,7 +252,7 @@ namespace UnitsNet.Serialization.JsonNet.Tests
                 {
                     Value = 10.0
                 };
-                JsonSerializerSettings jsonSerializerSettings = CreateJsonSerializerSettigns();
+                JsonSerializerSettings jsonSerializerSettings = CreateJsonSerializerSettings();
 
                 string json = JsonConvert.SerializeObject(testObjWithIComparable, jsonSerializerSettings);
 
@@ -269,7 +269,7 @@ namespace UnitsNet.Serialization.JsonNet.Tests
                 {
                     Value = new ComparableClass() { Value = 10 }
                 };
-                JsonSerializerSettings jsonSerializerSettings = CreateJsonSerializerSettigns();
+                JsonSerializerSettings jsonSerializerSettings = CreateJsonSerializerSettings();
 
                 string json = JsonConvert.SerializeObject(testObjWithIComparable, jsonSerializerSettings);
                 var deserializedTestObject = JsonConvert.DeserializeObject<TestObjWithIComparable>(json, jsonSerializerSettings);
@@ -286,7 +286,7 @@ namespace UnitsNet.Serialization.JsonNet.Tests
                    Value = 5,
                    Unit = "Test",
                 };
-                JsonSerializerSettings jsonSerializerSettings = CreateJsonSerializerSettigns();
+                JsonSerializerSettings jsonSerializerSettings = CreateJsonSerializerSettings();
 
                 string json = JsonConvert.SerializeObject(testObjWithValueAndUnit, jsonSerializerSettings);
                 TestObjWithValueAndUnit deserializedTestObject = JsonConvert.DeserializeObject<TestObjWithValueAndUnit>(json, jsonSerializerSettings);
@@ -308,20 +308,20 @@ namespace UnitsNet.Serialization.JsonNet.Tests
                     Value2 = comparable2,
                     Value3 = comparable3,
                 };
-                JsonSerializerSettings jsonSerializerSettings = CreateJsonSerializerSettigns();
+                JsonSerializerSettings jsonSerializerSettings = CreateJsonSerializerSettings();
 
                 string json = JsonConvert.SerializeObject(testObjWithIComparable, jsonSerializerSettings);
                 var deserializedTestObject = JsonConvert.DeserializeObject<TestObjWithThreeIComparable>(json, jsonSerializerSettings);
 
                 Assert.That(deserializedTestObject.Value1.GetType(), Is.EqualTo(comparable1.GetType()));
-                Assert.That(((deserializedTestObject.Value1)), Is.EqualTo(comparable1));
+                Assert.That((deserializedTestObject.Value1), Is.EqualTo(comparable1));
                 Assert.That(deserializedTestObject.Value2.GetType(), Is.EqualTo(comparable2.GetType()));
-                Assert.That(((deserializedTestObject.Value2)), Is.EqualTo(comparable2));
+                Assert.That((deserializedTestObject.Value2), Is.EqualTo(comparable2));
                 Assert.That(deserializedTestObject.Value3.GetType(), Is.EqualTo(comparable3.GetType()));
-                Assert.That(((deserializedTestObject.Value3)), Is.EqualTo(comparable3));
+                Assert.That((deserializedTestObject.Value3), Is.EqualTo(comparable3));
             }
 
-            public static object[] TestObjectsForThreeObjectsInIComparableWithDifferentValues_ExpectAllCorrectlyDeserialized
+            private static object[] TestObjectsForThreeObjectsInIComparableWithDifferentValues_ExpectAllCorrectlyDeserialized
             {
                 get
                 {
@@ -341,7 +341,7 @@ namespace UnitsNet.Serialization.JsonNet.Tests
                 }
             }
 
-            private static JsonSerializerSettings CreateJsonSerializerSettigns()
+            private static JsonSerializerSettings CreateJsonSerializerSettings()
             {
                 var jsonSerializerSettings = new JsonSerializerSettings()
                 {
@@ -353,13 +353,13 @@ namespace UnitsNet.Serialization.JsonNet.Tests
             }
         }
 
-        internal class TestObj
+        private class TestObj
         {
             public Frequency? NullableFrequency { get; set; }
             public Frequency NonNullableFrequency { get; set; }
         }
 
-        internal class TestObjWithValueAndUnit : IComparable
+        private class TestObjWithValueAndUnit : IComparable
         {
             public double Value { get; set; }
             public string Unit { get; set; }
@@ -370,7 +370,7 @@ namespace UnitsNet.Serialization.JsonNet.Tests
             }
         }
 
-        internal class ComparableClass : IComparable
+        private class ComparableClass : IComparable
         {
             public int Value { get; set; }
             public int CompareTo(object obj)
@@ -394,12 +394,12 @@ namespace UnitsNet.Serialization.JsonNet.Tests
             }
         }
 
-        internal class TestObjWithIComparable
+        private class TestObjWithIComparable
         {
             public IComparable Value { get; set; }
         }
 
-        internal class TestObjWithThreeIComparable
+        private class TestObjWithThreeIComparable
         {
             public IComparable Value1 { get; set; }
 

--- a/UnitsNet.Serialization.JsonNet.Tests/UnitsNetJsonConverterTests.cs
+++ b/UnitsNet.Serialization.JsonNet.Tests/UnitsNetJsonConverterTests.cs
@@ -359,10 +359,15 @@ namespace UnitsNet.Serialization.JsonNet.Tests
             public Frequency NonNullableFrequency { get; set; }
         }
 
-        internal class TestObjWithValueAndUnit
+        internal class TestObjWithValueAndUnit : IComparable
         {
             public double Value { get; set; }
             public string Unit { get; set; }
+
+            public int CompareTo(object obj)
+            {
+                return Value.CompareTo(obj);
+            }
         }
 
         internal class ComparableClass : IComparable

--- a/UnitsNet.Serialization.JsonNet.Tests/UnitsNetJsonConverterTests.cs
+++ b/UnitsNet.Serialization.JsonNet.Tests/UnitsNetJsonConverterTests.cs
@@ -296,49 +296,26 @@ namespace UnitsNet.Serialization.JsonNet.Tests
                 Assert.That(deserializedTestObject.Unit, Is.EqualTo("Test"));
             }
 
-            [Test, TestCaseSource(nameof(TestObjectsForThreeObjectsInIComparableWithDifferentValues_ExpectAllCorrectlyDeserialized))]
-            public void ThreeObjectsInIComparableWithDifferentValues_ExpectAllCorrectlyDeserialized(
-                IComparable comparable1,
-                IComparable comparable2,
-                IComparable comparable3)
+            [Test]
+            public void ThreeObjectsInIComparableWithDifferentValues_ExpectAllCorrectlyDeserialized()
             {
                 TestObjWithThreeIComparable testObjWithIComparable = new TestObjWithThreeIComparable()
                 {
-                    Value1 = comparable1,
-                    Value2 = comparable2,
-                    Value3 = comparable3,
+                    Value1 = 10.0,
+                    Value2 = Power.FromWatts(19),
+                    Value3 = new ComparableClass() { Value = 10 },
                 };
                 JsonSerializerSettings jsonSerializerSettings = CreateJsonSerializerSettings();
 
                 string json = JsonConvert.SerializeObject(testObjWithIComparable, jsonSerializerSettings);
                 var deserializedTestObject = JsonConvert.DeserializeObject<TestObjWithThreeIComparable>(json, jsonSerializerSettings);
 
-                Assert.That(deserializedTestObject.Value1.GetType(), Is.EqualTo(comparable1.GetType()));
-                Assert.That((deserializedTestObject.Value1), Is.EqualTo(comparable1));
-                Assert.That(deserializedTestObject.Value2.GetType(), Is.EqualTo(comparable2.GetType()));
-                Assert.That((deserializedTestObject.Value2), Is.EqualTo(comparable2));
-                Assert.That(deserializedTestObject.Value3.GetType(), Is.EqualTo(comparable3.GetType()));
-                Assert.That((deserializedTestObject.Value3), Is.EqualTo(comparable3));
-            }
-
-            private static object[] TestObjectsForThreeObjectsInIComparableWithDifferentValues_ExpectAllCorrectlyDeserialized
-            {
-                get
-                {
-                    List<object> result = new List<object>();
-                    var objects = new object[] { 10.0, Power.FromWatts(19), new ComparableClass() { Value = 10 } };
-                    for (int i = 0; i < objects.Length; i++)
-                    {
-                        for (int j = 0; j < objects.Length; j++)
-                        {
-                            for (int k = 0; k < objects.Length; k++)
-                            {
-                                result.Add(new object[] { objects[i], objects[j], objects[k]});
-                            }
-                        }
-                    }
-                    return result.ToArray();
-                }
+                Assert.That(deserializedTestObject.Value1.GetType(), Is.EqualTo(typeof(double)));
+                Assert.That((deserializedTestObject.Value1), Is.EqualTo(10.0));
+                Assert.That(deserializedTestObject.Value2.GetType(), Is.EqualTo(typeof(Power)));
+                Assert.That((deserializedTestObject.Value2), Is.EqualTo(Power.FromWatts(19)));
+                Assert.That(deserializedTestObject.Value3.GetType(), Is.EqualTo(typeof(ComparableClass)));
+                Assert.That((deserializedTestObject.Value3), Is.EqualTo(testObjWithIComparable.Value3));
             }
 
             private static JsonSerializerSettings CreateJsonSerializerSettings()

--- a/UnitsNet.Serialization.JsonNet.Tests/UnitsNetJsonConverterTests.cs
+++ b/UnitsNet.Serialization.JsonNet.Tests/UnitsNetJsonConverterTests.cs
@@ -226,12 +226,95 @@ namespace UnitsNet.Serialization.JsonNet.Tests
                 //  still deserializable, and the correct value of 1000 g is obtained.
                 Assert.That(deserializedMass.Grams, Is.EqualTo(1000));
             }
+
+            [Test]
+            public void UnitInIComparable_ExpectUnitCorrectlyDeserialized()
+            {
+                TestObjWithIComparable testObjWithIComparable = new TestObjWithIComparable()
+                {
+                    Value = Power.FromWatts(10)
+                };
+                var jsonSerializerSettings = new JsonSerializerSettings
+                {
+                    Formatting = Formatting.Indented,
+                    TypeNameHandling = TypeNameHandling.Objects
+                };
+                jsonSerializerSettings.Converters.Add(new UnitsNetJsonConverter());
+
+                string json = JsonConvert.SerializeObject(testObjWithIComparable,jsonSerializerSettings);
+
+                jsonSerializerSettings.TypeNameHandling = TypeNameHandling.Auto;
+                var deserializedTestObject = JsonConvert.DeserializeObject<TestObjWithIComparable>(json,jsonSerializerSettings);
+               
+                Assert.That(deserializedTestObject.Value.GetType(), Is.EqualTo(typeof(Power)));
+                Assert.That((Power)deserializedTestObject.Value, Is.EqualTo(Power.FromWatts(10)));
+            }
+
+            [Test]
+            public void DoubleInIComparable_ExpectUnitCorrectlyDeserialized()
+            {
+                TestObjWithIComparable testObjWithIComparable = new TestObjWithIComparable()
+                {
+                    Value = 10.0
+                };
+                var jsonSerializerSettings = new JsonSerializerSettings
+                {
+                    Formatting = Formatting.Indented,
+                    TypeNameHandling = TypeNameHandling.Objects
+                };
+                jsonSerializerSettings.Converters.Add(new UnitsNetJsonConverter());
+
+                string json = JsonConvert.SerializeObject(testObjWithIComparable, jsonSerializerSettings);
+
+                jsonSerializerSettings.TypeNameHandling = TypeNameHandling.Auto;
+                var deserializedTestObject = JsonConvert.DeserializeObject<TestObjWithIComparable>(json, jsonSerializerSettings);
+
+                Assert.That(deserializedTestObject.Value.GetType(), Is.EqualTo(typeof(double)));
+                Assert.That((double)deserializedTestObject.Value, Is.EqualTo(10.0));
+            }
+
+            [Test]
+            public void ClassInIComparable_ExpectUnitCorrectlyDeserialized()
+            {
+                TestObjWithIComparable testObjWithIComparable = new TestObjWithIComparable()
+                {
+                    Value = new ComparableClass() { Value = 10 }
+                };
+                var jsonSerializerSettings = new JsonSerializerSettings
+                {
+                    Formatting = Formatting.Indented,
+                    TypeNameHandling = TypeNameHandling.Objects
+                };
+                jsonSerializerSettings.Converters.Add(new UnitsNetJsonConverter());
+
+                string json = JsonConvert.SerializeObject(testObjWithIComparable, jsonSerializerSettings);
+
+                jsonSerializerSettings.TypeNameHandling = TypeNameHandling.Auto;
+                var deserializedTestObject = JsonConvert.DeserializeObject<TestObjWithIComparable>(json, jsonSerializerSettings);
+
+                Assert.That(deserializedTestObject.Value.GetType(), Is.EqualTo(typeof(ComparableClass)));
+                Assert.That(((ComparableClass)(deserializedTestObject.Value)).Value, Is.EqualTo(10.0));
+            }
         }
 
         internal class TestObj
         {
             public Frequency? NullableFrequency { get; set; }
             public Frequency NonNullableFrequency { get; set; }
+        }
+
+        internal class ComparableClass : IComparable
+        {
+            public int Value { get; set; }
+            public int CompareTo(object obj)
+            {
+                return Value.CompareTo(obj);
+            }
+        }
+
+        internal class TestObjWithIComparable
+        {
+            public IComparable Value { get; set; }
         }
     }
 }

--- a/UnitsNet.Serialization.JsonNet/UnitsNetJsonConverter.cs
+++ b/UnitsNet.Serialization.JsonNet/UnitsNetJsonConverter.cs
@@ -25,6 +25,7 @@ using System.Linq;
 using System.Reflection;
 using JetBrains.Annotations;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace UnitsNet.Serialization.JsonNet
 {
@@ -55,10 +56,17 @@ namespace UnitsNet.Serialization.JsonNet
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue,
             JsonSerializer serializer)
         {
-            var vu = serializer.Deserialize<ValueUnit>(reader);
-            // A null System.Nullable value was deserialized so just return null.
+            if (reader.ValueType != null)
+            {
+                return reader.Value;
+            }
+            object obj = TryDeserializeIComparable(reader, serializer);
+            var vu = obj as ValueUnit;
+            // A null System.Nullable value or a comparable type was deserialized so return this
             if (vu == null)
-                return null;
+            {
+                return obj;
+            }
 
             // "MassUnit.Kilogram" => "MassUnit" and "Kilogram"
             string unitEnumTypeName = vu.Unit.Split('.')[0];
@@ -102,8 +110,29 @@ namespace UnitsNet.Serialization.JsonNet
             // TODO: there is a possible loss of precision if base value requires higher precision than double can represent.
             // Example: Serializing Information.FromExabytes(100) then deserializing to Information 
             // will likely return a very different result. Not sure how we can handle this?
-            return fromMethod.Invoke(null, BindingFlags.Static, null, new[] {vu.Value, unit},
+            return fromMethod.Invoke(null, BindingFlags.Static, null, new[] { vu.Value, unit },
                 CultureInfo.InvariantCulture);
+        }
+
+        private static object TryDeserializeIComparable(JsonReader reader, JsonSerializer serializer)
+        {
+            JToken token = JToken.Load(reader);
+            if (!token.HasValues || token["Unit"] == null || token["Value"] == null)
+            {
+                JsonSerializer localSerializer = new JsonSerializer()
+                {
+                    TypeNameHandling = serializer.TypeNameHandling,
+                };
+                return token.ToObject<IComparable>(localSerializer);
+            }
+            else
+            {
+                return new ValueUnit()
+                {
+                    Unit = token["Unit"].ToString(),
+                    Value = token["Value"].ToObject<double>()
+                };
+            }
         }
 
         /// <summary>
@@ -117,6 +146,18 @@ namespace UnitsNet.Serialization.JsonNet
         {
             Type unitType = value.GetType();
 
+            // ValueUnit should be written as usual (but read in a custom way)
+            if(unitType == typeof(ValueUnit))
+            {
+                JsonSerializer localSerializer = new JsonSerializer()
+                {
+                    TypeNameHandling = serializer.TypeNameHandling,
+                };
+                JToken t = JToken.FromObject(value, localSerializer);
+                
+                t.WriteTo(writer);
+                return;
+            }
             FieldInfo[] fields =
                 unitType.GetFields(BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly);
             if (fields.Length == 0)
@@ -184,7 +225,12 @@ namespace UnitsNet.Serialization.JsonNet
                 return CanConvertNullable(objectType);
             }
 
-            return objectType.Namespace != null && objectType.Namespace.Equals("UnitsNet");
+            return objectType.Namespace != null && 
+                (objectType.Namespace.Equals("UnitsNet") || 
+                objectType == typeof(ValueUnit) || 
+                // All unit types implement IComparable
+                objectType==typeof(IComparable) ||
+                objectType.FullName.StartsWith("System." + nameof(IComparable)));
         }
 
         /// <summary>

--- a/UnitsNet.Serialization.JsonNet/UnitsNetJsonConverter.cs
+++ b/UnitsNet.Serialization.JsonNet/UnitsNetJsonConverter.cs
@@ -117,7 +117,7 @@ namespace UnitsNet.Serialization.JsonNet
         private static object TryDeserializeIComparable(JsonReader reader, JsonSerializer serializer)
         {
             JToken token = JToken.Load(reader);
-            if (!token.HasValues || token["Unit"] == null || token["Value"] == null)
+            if (!token.HasValues || token[nameof(ValueUnit.Unit)] == null || token[nameof(ValueUnit.Value)] == null)
             {
                 JsonSerializer localSerializer = new JsonSerializer()
                 {
@@ -129,8 +129,8 @@ namespace UnitsNet.Serialization.JsonNet
             {
                 return new ValueUnit()
                 {
-                    Unit = token["Unit"].ToString(),
-                    Value = token["Value"].ToObject<double>()
+                    Unit = token[nameof(ValueUnit.Unit)].ToString(),
+                    Value = token[nameof(ValueUnit.Value)].ToObject<double>()
                 };
             }
         }
@@ -225,12 +225,11 @@ namespace UnitsNet.Serialization.JsonNet
                 return CanConvertNullable(objectType);
             }
 
-            return objectType.Namespace != null && 
-                (objectType.Namespace.Equals("UnitsNet") || 
-                objectType == typeof(ValueUnit) || 
+            return objectType.Namespace != null &&
+                (objectType.Namespace.Equals(nameof(UnitsNet)) ||
+                objectType == typeof(ValueUnit) ||
                 // All unit types implement IComparable
-                objectType==typeof(IComparable) ||
-                objectType.FullName.StartsWith("System." + nameof(IComparable)));
+                objectType == typeof(IComparable));
         }
 
         /// <summary>
@@ -252,7 +251,7 @@ namespace UnitsNet.Serialization.JsonNet
         {
             // Need to look at the FullName in order to determine if the nullable type contains a UnitsNet type.
             // For example: FullName = 'System.Nullable`1[[UnitsNet.Frequency, UnitsNet, Version=3.19.0.0, Culture=neutral, PublicKeyToken=null]]'
-            return objectType.FullName != null && objectType.FullName.Contains("UnitsNet.");
+            return objectType.FullName != null && objectType.FullName.Contains(nameof(UnitsNet) + ".");
         }
 
         #endregion


### PR DESCRIPTION
I had a class that I needed to serialize that had a unit as a IComparable. This pull requests makes this possible. I've tried testing other alternatives to not break anything. Let me know if you can think of any other use cases that should be tested.
