### PR TITLE
Deprecated Pressure.Psi in favor of Pressure.PoundForcePerSquareInch.…

### DIFF
--- a/UnitsNet.Tests/CustomCode/PressureTests.cs
+++ b/UnitsNet.Tests/CustomCode/PressureTests.cs
@@ -59,7 +59,7 @@ namespace UnitsNet.Tests.CustomCode
 
         protected override double PoundsForcePerSquareFootInOnePascal => 0.0208854342;
 
-        protected override double PoundsForcePerSquareInchInOnePascal => 0.000145037738;
+        protected override double PoundsForcePerSquareInchInOnePascal => 0.000145037737730209;
 
         protected override double PsiInOnePascal => 1.450377*1E-4;
 

--- a/UnitsNet/GeneratedCode/Enums/PressureUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Enums/PressureUnit.g.cs
@@ -69,6 +69,7 @@ namespace UnitsNet.Units
         Pascal,
         PoundForcePerSquareFoot,
         PoundForcePerSquareInch,
+        [System.Obsolete("Deprecated due to github issue #215, please use PoundForcePerSquareInch instead")]
         Psi,
         TechnicalAtmosphere,
         TonneForcePerSquareCentimeter,

--- a/UnitsNet/GeneratedCode/UnitClasses/Pressure.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/Pressure.g.cs
@@ -243,7 +243,7 @@ namespace UnitsNet
         /// </summary>
         public double KilopoundsForcePerSquareInch
         {
-            get { return (_pascals*0.000145037725185479) / 1e3d; }
+            get { return (_pascals*0.000145037737730209) / 1e3d; }
         }
 
         /// <summary>
@@ -323,12 +323,13 @@ namespace UnitsNet
         /// </summary>
         public double PoundsForcePerSquareInch
         {
-            get { return _pascals*0.000145037725185479; }
+            get { return _pascals*0.000145037737730209; }
         }
 
         /// <summary>
         ///     Get Pressure in Psi.
         /// </summary>
+        [System.Obsolete("Deprecated due to github issue #215, please use PoundForcePerSquareInch instead")]
         public double Psi
         {
             get { return _pascals/(6.89464975179*1e3); }
@@ -516,7 +517,7 @@ namespace UnitsNet
         /// </summary>
         public static Pressure FromKilopoundsForcePerSquareInch(double kilopoundsforcepersquareinch)
         {
-            return new Pressure((kilopoundsforcepersquareinch*6894.75788951576) * 1e3d);
+            return new Pressure((kilopoundsforcepersquareinch*6894.75729316836) * 1e3d);
         }
 
         /// <summary>
@@ -596,7 +597,7 @@ namespace UnitsNet
         /// </summary>
         public static Pressure FromPoundsForcePerSquareInch(double poundsforcepersquareinch)
         {
-            return new Pressure(poundsforcepersquareinch*6894.75788951576);
+            return new Pressure(poundsforcepersquareinch*6894.75729316836);
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/UnitSystem.Default.g.cs
+++ b/UnitsNet/GeneratedCode/UnitSystem.Default.g.cs
@@ -1593,7 +1593,7 @@ namespace UnitsNet
                         new CulturesForEnumValue((int) PressureUnit.PoundForcePerSquareInch,
                             new[]
                             {
-                                new AbbreviationsForCulture("en-US", "lb/in²"),
+                                new AbbreviationsForCulture("en-US", "psi", "lb/in²"),
                             }),
                         new CulturesForEnumValue((int) PressureUnit.Psi,
                             new[]

--- a/UnitsNet/Scripts/UnitDefinitions/Pressure.json
+++ b/UnitsNet/Scripts/UnitDefinitions/Pressure.json
@@ -162,6 +162,7 @@
     {
       "SingularName": "Psi",
       "PluralName": "Psi",
+      "ObsoleteText": "Deprecated due to github issue #215, please use PoundForcePerSquareInch instead",      
       "FromUnitToBaseFunc": "x*6.89464975179*1e3",
       "FromBaseToUnitFunc": "x/(6.89464975179*1e3)",
       "Localization": [
@@ -210,13 +211,13 @@
     {
       "SingularName": "PoundForcePerSquareInch",
       "PluralName": "PoundsForcePerSquareInch",
-      "FromUnitToBaseFunc": "x*6894.75788951576",
-      "FromBaseToUnitFunc": "x*0.000145037725185479",
+      "FromUnitToBaseFunc": "x*6894.75729316836",
+      "FromBaseToUnitFunc": "x*0.000145037737730209",
       "Prefixes": [ "Kilo" ],
       "Localization": [
         {
           "Culture": "en-US",
-          "Abbreviations": [ "lb/in²" ],
+          "Abbreviations": [ "psi", "lb/in²" ],
           "AbbreviationsWithPrefixes": [ "kipf/in²" ]
         }
       ]


### PR DESCRIPTION
… Alterered conversion factor for Pressure.PoundForcePerSquareInch to be exact and added "psi" as preferred en-US abbreviation. Issue #215