### PR TITLE
Fix UnitParser.ParseUnit for multiple-worded units

### DIFF
--- a/UnitsNet.Tests/CustomCode/ParseTests.cs
+++ b/UnitsNet.Tests/CustomCode/ParseTests.cs
@@ -42,7 +42,7 @@ namespace UnitsNet.Tests.CustomCode
         [TestCase("500,005 m", Result = 500005)]
         [TestCase(null, ExpectedExceptionName = "System.ArgumentNullException")]
         [TestCase("1", ExpectedExceptionName = "System.ArgumentException")]
-        [TestCase("km", ExpectedExceptionName = "UnitsNet.UnitsNetException")]
+        [TestCase("km", ExpectedExceptionName = "System.ArgumentException")]
         [TestCase("1 kg", ExpectedExceptionName = "UnitsNet.UnitsNetException")]
         public double ParseLengthToMetersUsEnglish(string s)
         {
@@ -115,6 +115,17 @@ namespace UnitsNet.Tests.CustomCode
             CultureInfo usEnglish = CultureInfo.GetCultureInfo("en-US");
             Length result;
             return Length.TryParse(s, usEnglish, out result);
+        }
+
+        [TestCase("333 short tn", Result = 333)]
+        public double ParseMassShortTon(string s)
+        {
+            return Mass.Parse(s).ShortTons;
+        }
+        [TestCase("333 long tn", Result = 333)]
+        public double ParseMassLongTon(string s)
+        {
+            return Mass.Parse(s).LongTons;
         }
     }
 }

--- a/UnitsNet.Tests/CustomCode/SpeedTests.cs
+++ b/UnitsNet.Tests/CustomCode/SpeedTests.cs
@@ -68,6 +68,12 @@ namespace UnitsNet.Tests.CustomCode
 
         protected override double MillimetersPerHourInOneMeterPerSecond => 3600000;
 
+        protected override double InchesPerSecondInOneMeterPerSecond => 39.3700787;
+
+        protected override double YardsPerMinuteInOneMeterPerSecond => 65.6167979;
+
+        protected override double YardsPerSecondInOneMeterPerSecond => 1.09361330;
+
         [Test]
         public void DurationSpeedTimesEqualsLength()
         {

--- a/UnitsNet.Tests/GeneratedCode/SpeedTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/SpeedTestsBase.g.cs
@@ -59,6 +59,7 @@ namespace UnitsNet.Tests
         protected abstract double DecimetersPerMinutesInOneMeterPerSecond { get; }
         protected abstract double DecimetersPerSecondInOneMeterPerSecond { get; }
         protected abstract double FeetPerSecondInOneMeterPerSecond { get; }
+        protected abstract double InchesPerSecondInOneMeterPerSecond { get; }
         protected abstract double KilometersPerHourInOneMeterPerSecond { get; }
         protected abstract double KilometersPerMinutesInOneMeterPerSecond { get; }
         protected abstract double KilometersPerSecondInOneMeterPerSecond { get; }
@@ -74,6 +75,8 @@ namespace UnitsNet.Tests
         protected abstract double MillimetersPerSecondInOneMeterPerSecond { get; }
         protected abstract double NanometersPerMinutesInOneMeterPerSecond { get; }
         protected abstract double NanometersPerSecondInOneMeterPerSecond { get; }
+        protected abstract double YardsPerMinuteInOneMeterPerSecond { get; }
+        protected abstract double YardsPerSecondInOneMeterPerSecond { get; }
 
 // ReSharper disable VirtualMemberNeverOverriden.Global
         protected virtual double CentimetersPerHourTolerance { get { return 1e-5; } }
@@ -82,6 +85,7 @@ namespace UnitsNet.Tests
         protected virtual double DecimetersPerMinutesTolerance { get { return 1e-5; } }
         protected virtual double DecimetersPerSecondTolerance { get { return 1e-5; } }
         protected virtual double FeetPerSecondTolerance { get { return 1e-5; } }
+        protected virtual double InchesPerSecondTolerance { get { return 1e-5; } }
         protected virtual double KilometersPerHourTolerance { get { return 1e-5; } }
         protected virtual double KilometersPerMinutesTolerance { get { return 1e-5; } }
         protected virtual double KilometersPerSecondTolerance { get { return 1e-5; } }
@@ -97,6 +101,8 @@ namespace UnitsNet.Tests
         protected virtual double MillimetersPerSecondTolerance { get { return 1e-5; } }
         protected virtual double NanometersPerMinutesTolerance { get { return 1e-5; } }
         protected virtual double NanometersPerSecondTolerance { get { return 1e-5; } }
+        protected virtual double YardsPerMinuteTolerance { get { return 1e-5; } }
+        protected virtual double YardsPerSecondTolerance { get { return 1e-5; } }
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         [Test]
@@ -109,6 +115,7 @@ namespace UnitsNet.Tests
             Assert.AreEqual(DecimetersPerMinutesInOneMeterPerSecond, meterpersecond.DecimetersPerMinutes, DecimetersPerMinutesTolerance);
             Assert.AreEqual(DecimetersPerSecondInOneMeterPerSecond, meterpersecond.DecimetersPerSecond, DecimetersPerSecondTolerance);
             Assert.AreEqual(FeetPerSecondInOneMeterPerSecond, meterpersecond.FeetPerSecond, FeetPerSecondTolerance);
+            Assert.AreEqual(InchesPerSecondInOneMeterPerSecond, meterpersecond.InchesPerSecond, InchesPerSecondTolerance);
             Assert.AreEqual(KilometersPerHourInOneMeterPerSecond, meterpersecond.KilometersPerHour, KilometersPerHourTolerance);
             Assert.AreEqual(KilometersPerMinutesInOneMeterPerSecond, meterpersecond.KilometersPerMinutes, KilometersPerMinutesTolerance);
             Assert.AreEqual(KilometersPerSecondInOneMeterPerSecond, meterpersecond.KilometersPerSecond, KilometersPerSecondTolerance);
@@ -124,6 +131,8 @@ namespace UnitsNet.Tests
             Assert.AreEqual(MillimetersPerSecondInOneMeterPerSecond, meterpersecond.MillimetersPerSecond, MillimetersPerSecondTolerance);
             Assert.AreEqual(NanometersPerMinutesInOneMeterPerSecond, meterpersecond.NanometersPerMinutes, NanometersPerMinutesTolerance);
             Assert.AreEqual(NanometersPerSecondInOneMeterPerSecond, meterpersecond.NanometersPerSecond, NanometersPerSecondTolerance);
+            Assert.AreEqual(YardsPerMinuteInOneMeterPerSecond, meterpersecond.YardsPerMinute, YardsPerMinuteTolerance);
+            Assert.AreEqual(YardsPerSecondInOneMeterPerSecond, meterpersecond.YardsPerSecond, YardsPerSecondTolerance);
         }
 
         [Test]
@@ -135,6 +144,7 @@ namespace UnitsNet.Tests
             Assert.AreEqual(1, Speed.From(1, SpeedUnit.DecimeterPerMinute).DecimetersPerMinutes, DecimetersPerMinutesTolerance);
             Assert.AreEqual(1, Speed.From(1, SpeedUnit.DecimeterPerSecond).DecimetersPerSecond, DecimetersPerSecondTolerance);
             Assert.AreEqual(1, Speed.From(1, SpeedUnit.FootPerSecond).FeetPerSecond, FeetPerSecondTolerance);
+            Assert.AreEqual(1, Speed.From(1, SpeedUnit.InchPerSecond).InchesPerSecond, InchesPerSecondTolerance);
             Assert.AreEqual(1, Speed.From(1, SpeedUnit.KilometerPerHour).KilometersPerHour, KilometersPerHourTolerance);
             Assert.AreEqual(1, Speed.From(1, SpeedUnit.KilometerPerMinute).KilometersPerMinutes, KilometersPerMinutesTolerance);
             Assert.AreEqual(1, Speed.From(1, SpeedUnit.KilometerPerSecond).KilometersPerSecond, KilometersPerSecondTolerance);
@@ -150,6 +160,8 @@ namespace UnitsNet.Tests
             Assert.AreEqual(1, Speed.From(1, SpeedUnit.MillimeterPerSecond).MillimetersPerSecond, MillimetersPerSecondTolerance);
             Assert.AreEqual(1, Speed.From(1, SpeedUnit.NanometerPerMinute).NanometersPerMinutes, NanometersPerMinutesTolerance);
             Assert.AreEqual(1, Speed.From(1, SpeedUnit.NanometerPerSecond).NanometersPerSecond, NanometersPerSecondTolerance);
+            Assert.AreEqual(1, Speed.From(1, SpeedUnit.YardPerMinute).YardsPerMinute, YardsPerMinuteTolerance);
+            Assert.AreEqual(1, Speed.From(1, SpeedUnit.YardPerSecond).YardsPerSecond, YardsPerSecondTolerance);
         }
 
         [Test]
@@ -162,6 +174,7 @@ namespace UnitsNet.Tests
             Assert.AreEqual(DecimetersPerMinutesInOneMeterPerSecond, meterpersecond.As(SpeedUnit.DecimeterPerMinute), DecimetersPerMinutesTolerance);
             Assert.AreEqual(DecimetersPerSecondInOneMeterPerSecond, meterpersecond.As(SpeedUnit.DecimeterPerSecond), DecimetersPerSecondTolerance);
             Assert.AreEqual(FeetPerSecondInOneMeterPerSecond, meterpersecond.As(SpeedUnit.FootPerSecond), FeetPerSecondTolerance);
+            Assert.AreEqual(InchesPerSecondInOneMeterPerSecond, meterpersecond.As(SpeedUnit.InchPerSecond), InchesPerSecondTolerance);
             Assert.AreEqual(KilometersPerHourInOneMeterPerSecond, meterpersecond.As(SpeedUnit.KilometerPerHour), KilometersPerHourTolerance);
             Assert.AreEqual(KilometersPerMinutesInOneMeterPerSecond, meterpersecond.As(SpeedUnit.KilometerPerMinute), KilometersPerMinutesTolerance);
             Assert.AreEqual(KilometersPerSecondInOneMeterPerSecond, meterpersecond.As(SpeedUnit.KilometerPerSecond), KilometersPerSecondTolerance);
@@ -177,6 +190,8 @@ namespace UnitsNet.Tests
             Assert.AreEqual(MillimetersPerSecondInOneMeterPerSecond, meterpersecond.As(SpeedUnit.MillimeterPerSecond), MillimetersPerSecondTolerance);
             Assert.AreEqual(NanometersPerMinutesInOneMeterPerSecond, meterpersecond.As(SpeedUnit.NanometerPerMinute), NanometersPerMinutesTolerance);
             Assert.AreEqual(NanometersPerSecondInOneMeterPerSecond, meterpersecond.As(SpeedUnit.NanometerPerSecond), NanometersPerSecondTolerance);
+            Assert.AreEqual(YardsPerMinuteInOneMeterPerSecond, meterpersecond.As(SpeedUnit.YardPerMinute), YardsPerMinuteTolerance);
+            Assert.AreEqual(YardsPerSecondInOneMeterPerSecond, meterpersecond.As(SpeedUnit.YardPerSecond), YardsPerSecondTolerance);
         }
 
         [Test]
@@ -189,6 +204,7 @@ namespace UnitsNet.Tests
             Assert.AreEqual(1, Speed.FromDecimetersPerMinutes(meterpersecond.DecimetersPerMinutes).MetersPerSecond, DecimetersPerMinutesTolerance);
             Assert.AreEqual(1, Speed.FromDecimetersPerSecond(meterpersecond.DecimetersPerSecond).MetersPerSecond, DecimetersPerSecondTolerance);
             Assert.AreEqual(1, Speed.FromFeetPerSecond(meterpersecond.FeetPerSecond).MetersPerSecond, FeetPerSecondTolerance);
+            Assert.AreEqual(1, Speed.FromInchesPerSecond(meterpersecond.InchesPerSecond).MetersPerSecond, InchesPerSecondTolerance);
             Assert.AreEqual(1, Speed.FromKilometersPerHour(meterpersecond.KilometersPerHour).MetersPerSecond, KilometersPerHourTolerance);
             Assert.AreEqual(1, Speed.FromKilometersPerMinutes(meterpersecond.KilometersPerMinutes).MetersPerSecond, KilometersPerMinutesTolerance);
             Assert.AreEqual(1, Speed.FromKilometersPerSecond(meterpersecond.KilometersPerSecond).MetersPerSecond, KilometersPerSecondTolerance);
@@ -204,6 +220,8 @@ namespace UnitsNet.Tests
             Assert.AreEqual(1, Speed.FromMillimetersPerSecond(meterpersecond.MillimetersPerSecond).MetersPerSecond, MillimetersPerSecondTolerance);
             Assert.AreEqual(1, Speed.FromNanometersPerMinutes(meterpersecond.NanometersPerMinutes).MetersPerSecond, NanometersPerMinutesTolerance);
             Assert.AreEqual(1, Speed.FromNanometersPerSecond(meterpersecond.NanometersPerSecond).MetersPerSecond, NanometersPerSecondTolerance);
+            Assert.AreEqual(1, Speed.FromYardsPerMinute(meterpersecond.YardsPerMinute).MetersPerSecond, YardsPerMinuteTolerance);
+            Assert.AreEqual(1, Speed.FromYardsPerSecond(meterpersecond.YardsPerSecond).MetersPerSecond, YardsPerSecondTolerance);
         }
 
         [Test]

--- a/UnitsNet/CustomCode/UnitParser.cs
+++ b/UnitsNet/CustomCode/UnitParser.cs
@@ -54,13 +54,14 @@ namespace UnitsNet
 
             const string exponentialRegex = @"(?:[eE][-+]?\d+)?)";
 
-            string regexString = string.Format(@"(?:\s*(?<value>[-+]?{0}{1}{2}{3})?{4}{5}",
+            string regexString = string.Format(@"(?:\s*(?<value>[-+]?{0}{1}{2}{3})?",
                 numRegex, // capture base (integral) Quantity value
                 exponentialRegex, // capture exponential (if any), end of Quantity capturing
                 @"\s?", // ignore whitespace (allows both "1kg", "1 kg")
-                @"(?<unit>[^\s\d,]+)", // capture Unit (non-whitespace) input
-                @"(and)?,?", // allow "and" & "," separators between quantities
-                @"(?<invalid>[a-z]*)?"); // capture invalid input
+                @"(?<unit>[^\d]+)"); // capture Unit (non-numeric)
+
+            //remove separators
+            str = str.Replace("and", ""); 
 
             List<TUnit> quantities = ParseWithRegex(regexString, str, parseUnit, formatProvider);
             if (quantities.Count == 0)
@@ -89,15 +90,7 @@ namespace UnitsNet
 
                 string valueString = groups["value"].Value;
                 string unitString = groups["unit"].Value;
-                if (groups["invalid"].Value != "")
-                {
-                    var newEx = new UnitsNetException("Invalid string detected: " + groups["invalid"].Value);
-                    newEx.Data["input"] = str;
-                    newEx.Data["matched value"] = valueString;
-                    newEx.Data["matched unit"] = unitString;
-                    newEx.Data["formatprovider"] = formatProvider?.ToString();
-                    throw newEx;
-                }
+
                 if ((valueString == "") && (unitString == "")) continue;
 
                 try

--- a/UnitsNet/GeneratedCode/Enums/SpeedUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Enums/SpeedUnit.g.cs
@@ -48,6 +48,7 @@ namespace UnitsNet.Units
         DecimeterPerMinute,
         DecimeterPerSecond,
         FootPerSecond,
+        InchPerSecond,
         KilometerPerHour,
         KilometerPerMinute,
         KilometerPerSecond,
@@ -63,5 +64,7 @@ namespace UnitsNet.Units
         MillimeterPerSecond,
         NanometerPerMinute,
         NanometerPerSecond,
+        YardPerMinute,
+        YardPerSecond,
     }
 }

--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToSpeedExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToSpeedExtensions.g.cs
@@ -248,6 +248,40 @@ namespace UnitsNet.Extensions.NumberToSpeed
 
         #endregion
 
+        #region InchPerSecond
+
+        /// <inheritdoc cref="Speed.FromInchesPerSecond(double)"/>
+        public static Speed InchesPerSecond(this int value) => Speed.FromInchesPerSecond(value);
+
+        /// <inheritdoc cref="Speed.FromInchesPerSecond(double?)"/>
+        public static Speed? InchesPerSecond(this int? value) => Speed.FromInchesPerSecond(value);
+
+        /// <inheritdoc cref="Speed.FromInchesPerSecond(double)"/>
+        public static Speed InchesPerSecond(this long value) => Speed.FromInchesPerSecond(value);
+
+        /// <inheritdoc cref="Speed.FromInchesPerSecond(double?)"/>
+        public static Speed? InchesPerSecond(this long? value) => Speed.FromInchesPerSecond(value);
+
+        /// <inheritdoc cref="Speed.FromInchesPerSecond(double)"/>
+        public static Speed InchesPerSecond(this double value) => Speed.FromInchesPerSecond(value);
+
+        /// <inheritdoc cref="Speed.FromInchesPerSecond(double?)"/>
+        public static Speed? InchesPerSecond(this double? value) => Speed.FromInchesPerSecond(value);
+
+        /// <inheritdoc cref="Speed.FromInchesPerSecond(double)"/>
+        public static Speed InchesPerSecond(this float value) => Speed.FromInchesPerSecond(value);
+
+        /// <inheritdoc cref="Speed.FromInchesPerSecond(double?)"/>
+        public static Speed? InchesPerSecond(this float? value) => Speed.FromInchesPerSecond(value);
+
+        /// <inheritdoc cref="Speed.FromInchesPerSecond(double)"/>
+        public static Speed InchesPerSecond(this decimal value) => Speed.FromInchesPerSecond(Convert.ToDouble(value));
+
+        /// <inheritdoc cref="Speed.FromInchesPerSecond(double?)"/>
+        public static Speed? InchesPerSecond(this decimal? value) => Speed.FromInchesPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
+
+        #endregion
+
         #region KilometerPerHour
 
         /// <inheritdoc cref="Speed.FromKilometersPerHour(double)"/>
@@ -755,6 +789,74 @@ namespace UnitsNet.Extensions.NumberToSpeed
 
         /// <inheritdoc cref="Speed.FromNanometersPerSecond(double?)"/>
         public static Speed? NanometersPerSecond(this decimal? value) => Speed.FromNanometersPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
+
+        #endregion
+
+        #region YardPerMinute
+
+        /// <inheritdoc cref="Speed.FromYardsPerMinute(double)"/>
+        public static Speed YardsPerMinute(this int value) => Speed.FromYardsPerMinute(value);
+
+        /// <inheritdoc cref="Speed.FromYardsPerMinute(double?)"/>
+        public static Speed? YardsPerMinute(this int? value) => Speed.FromYardsPerMinute(value);
+
+        /// <inheritdoc cref="Speed.FromYardsPerMinute(double)"/>
+        public static Speed YardsPerMinute(this long value) => Speed.FromYardsPerMinute(value);
+
+        /// <inheritdoc cref="Speed.FromYardsPerMinute(double?)"/>
+        public static Speed? YardsPerMinute(this long? value) => Speed.FromYardsPerMinute(value);
+
+        /// <inheritdoc cref="Speed.FromYardsPerMinute(double)"/>
+        public static Speed YardsPerMinute(this double value) => Speed.FromYardsPerMinute(value);
+
+        /// <inheritdoc cref="Speed.FromYardsPerMinute(double?)"/>
+        public static Speed? YardsPerMinute(this double? value) => Speed.FromYardsPerMinute(value);
+
+        /// <inheritdoc cref="Speed.FromYardsPerMinute(double)"/>
+        public static Speed YardsPerMinute(this float value) => Speed.FromYardsPerMinute(value);
+
+        /// <inheritdoc cref="Speed.FromYardsPerMinute(double?)"/>
+        public static Speed? YardsPerMinute(this float? value) => Speed.FromYardsPerMinute(value);
+
+        /// <inheritdoc cref="Speed.FromYardsPerMinute(double)"/>
+        public static Speed YardsPerMinute(this decimal value) => Speed.FromYardsPerMinute(Convert.ToDouble(value));
+
+        /// <inheritdoc cref="Speed.FromYardsPerMinute(double?)"/>
+        public static Speed? YardsPerMinute(this decimal? value) => Speed.FromYardsPerMinute(value == null ? (double?)null : Convert.ToDouble(value.Value));
+
+        #endregion
+
+        #region YardPerSecond
+
+        /// <inheritdoc cref="Speed.FromYardsPerSecond(double)"/>
+        public static Speed YardsPerSecond(this int value) => Speed.FromYardsPerSecond(value);
+
+        /// <inheritdoc cref="Speed.FromYardsPerSecond(double?)"/>
+        public static Speed? YardsPerSecond(this int? value) => Speed.FromYardsPerSecond(value);
+
+        /// <inheritdoc cref="Speed.FromYardsPerSecond(double)"/>
+        public static Speed YardsPerSecond(this long value) => Speed.FromYardsPerSecond(value);
+
+        /// <inheritdoc cref="Speed.FromYardsPerSecond(double?)"/>
+        public static Speed? YardsPerSecond(this long? value) => Speed.FromYardsPerSecond(value);
+
+        /// <inheritdoc cref="Speed.FromYardsPerSecond(double)"/>
+        public static Speed YardsPerSecond(this double value) => Speed.FromYardsPerSecond(value);
+
+        /// <inheritdoc cref="Speed.FromYardsPerSecond(double?)"/>
+        public static Speed? YardsPerSecond(this double? value) => Speed.FromYardsPerSecond(value);
+
+        /// <inheritdoc cref="Speed.FromYardsPerSecond(double)"/>
+        public static Speed YardsPerSecond(this float value) => Speed.FromYardsPerSecond(value);
+
+        /// <inheritdoc cref="Speed.FromYardsPerSecond(double?)"/>
+        public static Speed? YardsPerSecond(this float? value) => Speed.FromYardsPerSecond(value);
+
+        /// <inheritdoc cref="Speed.FromYardsPerSecond(double)"/>
+        public static Speed YardsPerSecond(this decimal value) => Speed.FromYardsPerSecond(Convert.ToDouble(value));
+
+        /// <inheritdoc cref="Speed.FromYardsPerSecond(double?)"/>
+        public static Speed? YardsPerSecond(this decimal? value) => Speed.FromYardsPerSecond(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/UnitClasses/Speed.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/Speed.g.cs
@@ -159,6 +159,14 @@ namespace UnitsNet
         }
 
         /// <summary>
+        ///     Get Speed in InchesPerSecond.
+        /// </summary>
+        public double InchesPerSecond
+        {
+            get { return _metersPerSecond/2.54e-2; }
+        }
+
+        /// <summary>
         ///     Get Speed in KilometersPerHour.
         /// </summary>
         public double KilometersPerHour
@@ -278,6 +286,22 @@ namespace UnitsNet
             get { return (_metersPerSecond) / 1e-9d; }
         }
 
+        /// <summary>
+        ///     Get Speed in YardsPerMinute.
+        /// </summary>
+        public double YardsPerMinute
+        {
+            get { return _metersPerSecond/0.9144*60; }
+        }
+
+        /// <summary>
+        ///     Get Speed in YardsPerSecond.
+        /// </summary>
+        public double YardsPerSecond
+        {
+            get { return _metersPerSecond/0.9144; }
+        }
+
         #endregion
 
         #region Static
@@ -333,6 +357,14 @@ namespace UnitsNet
         public static Speed FromFeetPerSecond(double feetpersecond)
         {
             return new Speed(feetpersecond*0.3048);
+        }
+
+        /// <summary>
+        ///     Get Speed from InchesPerSecond.
+        /// </summary>
+        public static Speed FromInchesPerSecond(double inchespersecond)
+        {
+            return new Speed(inchespersecond*2.54e-2);
         }
 
         /// <summary>
@@ -455,6 +487,22 @@ namespace UnitsNet
             return new Speed((nanometerspersecond) * 1e-9d);
         }
 
+        /// <summary>
+        ///     Get Speed from YardsPerMinute.
+        /// </summary>
+        public static Speed FromYardsPerMinute(double yardsperminute)
+        {
+            return new Speed(yardsperminute*0.9144/60);
+        }
+
+        /// <summary>
+        ///     Get Speed from YardsPerSecond.
+        /// </summary>
+        public static Speed FromYardsPerSecond(double yardspersecond)
+        {
+            return new Speed(yardspersecond*0.9144);
+        }
+
 #if !WINDOWS_UWP
         /// <summary>
         ///     Get nullable Speed from nullable CentimetersPerHour.
@@ -539,6 +587,21 @@ namespace UnitsNet
             if (feetpersecond.HasValue)
             {
                 return FromFeetPerSecond(feetpersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
+        ///     Get nullable Speed from nullable InchesPerSecond.
+        /// </summary>
+        public static Speed? FromInchesPerSecond(double? inchespersecond)
+        {
+            if (inchespersecond.HasValue)
+            {
+                return FromInchesPerSecond(inchespersecond.Value);
             }
             else
             {
@@ -771,6 +834,36 @@ namespace UnitsNet
             }
         }
 
+        /// <summary>
+        ///     Get nullable Speed from nullable YardsPerMinute.
+        /// </summary>
+        public static Speed? FromYardsPerMinute(double? yardsperminute)
+        {
+            if (yardsperminute.HasValue)
+            {
+                return FromYardsPerMinute(yardsperminute.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
+        ///     Get nullable Speed from nullable YardsPerSecond.
+        /// </summary>
+        public static Speed? FromYardsPerSecond(double? yardspersecond)
+        {
+            if (yardspersecond.HasValue)
+            {
+                return FromYardsPerSecond(yardspersecond.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
 #endif
 
         /// <summary>
@@ -795,6 +888,8 @@ namespace UnitsNet
                     return FromDecimetersPerSecond(val);
                 case SpeedUnit.FootPerSecond:
                     return FromFeetPerSecond(val);
+                case SpeedUnit.InchPerSecond:
+                    return FromInchesPerSecond(val);
                 case SpeedUnit.KilometerPerHour:
                     return FromKilometersPerHour(val);
                 case SpeedUnit.KilometerPerMinute:
@@ -825,6 +920,10 @@ namespace UnitsNet
                     return FromNanometersPerMinutes(val);
                 case SpeedUnit.NanometerPerSecond:
                     return FromNanometersPerSecond(val);
+                case SpeedUnit.YardPerMinute:
+                    return FromYardsPerMinute(val);
+                case SpeedUnit.YardPerSecond:
+                    return FromYardsPerSecond(val);
 
                 default:
                     throw new NotImplementedException("fromUnit: " + fromUnit);
@@ -858,6 +957,8 @@ namespace UnitsNet
                     return FromDecimetersPerSecond(value.Value);
                 case SpeedUnit.FootPerSecond:
                     return FromFeetPerSecond(value.Value);
+                case SpeedUnit.InchPerSecond:
+                    return FromInchesPerSecond(value.Value);
                 case SpeedUnit.KilometerPerHour:
                     return FromKilometersPerHour(value.Value);
                 case SpeedUnit.KilometerPerMinute:
@@ -888,6 +989,10 @@ namespace UnitsNet
                     return FromNanometersPerMinutes(value.Value);
                 case SpeedUnit.NanometerPerSecond:
                     return FromNanometersPerSecond(value.Value);
+                case SpeedUnit.YardPerMinute:
+                    return FromYardsPerMinute(value.Value);
+                case SpeedUnit.YardPerSecond:
+                    return FromYardsPerSecond(value.Value);
 
                 default:
                     throw new NotImplementedException("fromUnit: " + fromUnit);
@@ -1054,6 +1159,8 @@ namespace UnitsNet
                     return DecimetersPerSecond;
                 case SpeedUnit.FootPerSecond:
                     return FeetPerSecond;
+                case SpeedUnit.InchPerSecond:
+                    return InchesPerSecond;
                 case SpeedUnit.KilometerPerHour:
                     return KilometersPerHour;
                 case SpeedUnit.KilometerPerMinute:
@@ -1084,6 +1191,10 @@ namespace UnitsNet
                     return NanometersPerMinutes;
                 case SpeedUnit.NanometerPerSecond:
                     return NanometersPerSecond;
+                case SpeedUnit.YardPerMinute:
+                    return YardsPerMinute;
+                case SpeedUnit.YardPerSecond:
+                    return YardsPerSecond;
 
                 default:
                     throw new NotImplementedException("unit: " + unit);

--- a/UnitsNet/GeneratedCode/UnitSystem.Default.g.cs
+++ b/UnitsNet/GeneratedCode/UnitSystem.Default.g.cs
@@ -2273,6 +2273,11 @@ namespace UnitsNet
                             {
                                 new AbbreviationsForCulture("en-US", "ft/s"),
                             }),
+                        new CulturesForEnumValue((int) SpeedUnit.InchPerSecond,
+                            new[]
+                            {
+                                new AbbreviationsForCulture("en-US", "in/s"),
+                            }),
                         new CulturesForEnumValue((int) SpeedUnit.KilometerPerHour,
                             new[]
                             {
@@ -2347,6 +2352,16 @@ namespace UnitsNet
                             new[]
                             {
                                 new AbbreviationsForCulture("en-US", "nm/s"),
+                            }),
+                        new CulturesForEnumValue((int) SpeedUnit.YardPerMinute,
+                            new[]
+                            {
+                                new AbbreviationsForCulture("en-US", "yd/min"),
+                            }),
+                        new CulturesForEnumValue((int) SpeedUnit.YardPerSecond,
+                            new[]
+                            {
+                                new AbbreviationsForCulture("en-US", "yd/s"),
                             }),
                     }),
                 new UnitLocalization(typeof (TemperatureUnit),

--- a/UnitsNet/UnitDefinitions/Speed.json
+++ b/UnitsNet/UnitDefinitions/Speed.json
@@ -77,6 +77,42 @@
           "Abbreviations": [ "mph" ]
         }
       ]
+    },
+    {
+      "SingularName": "InchPerSecond",
+      "PluralName": "InchesPerSecond",
+      "FromUnitToBaseFunc": "x*2.54e-2",
+      "FromBaseToUnitFunc": "x/2.54e-2",
+      "Localization": [
+        {
+          "Culture": "en-US",
+          "Abbreviations": [ "in/s" ]
+        }
+      ]
+    },
+    {
+      "SingularName": "YardPerSecond",
+      "PluralName": "YardsPerSecond",
+      "FromUnitToBaseFunc": "x*0.9144",
+      "FromBaseToUnitFunc": "x/0.9144",
+      "Localization": [
+        {
+          "Culture": "en-US",
+          "Abbreviations": [ "yd/s" ]
+        }
+      ]
+    },
+    {
+      "SingularName": "YardPerMinute",
+      "PluralName": "YardsPerMinute",
+      "FromUnitToBaseFunc": "x*0.9144/60",
+      "FromBaseToUnitFunc": "x/0.9144*60",
+      "Localization": [
+        {
+          "Culture": "en-US",
+          "Abbreviations": [ "yd/min" ]
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
https://github.com/anjdreas/UnitsNet/issues/253

1. Changed regex to accept multiple worded non-numeric units
2. Used string.Replace to remove all known separators. This way, we
don't need to include it in our regex. Also the separator "," is already
defined in NumberFormatInfo numFormat
3. Removed code block for <invalid> group since it will not go into this
anymore.
4. Added Unit test for Parsing Mass "Short Tons" and "Long Tons"