### PR TITLE
Bugfix/parse mapped abbrev

### DIFF
--- a/UnitsNet.Tests/CustomCode/ParseTests.cs
+++ b/UnitsNet.Tests/CustomCode/ParseTests.cs
@@ -177,6 +177,7 @@ namespace UnitsNet.Tests.CustomCode
         [InlineData("_")]
         [InlineData("?")]
         [InlineData("123")]
+        [InlineData("od to")]
         public void TryParseLengthUnitAbbreviation(string s)
         {
             UnitSystem unitSystem = UnitSystem.GetCached("en-US");
@@ -201,6 +202,7 @@ namespace UnitsNet.Tests.CustomCode
         [InlineData("_")]
         [InlineData("?")]
         [InlineData("123")]
+        [InlineData("od to")]
         public void TryParseLengthUnitAbbreviationWithNumbers(string s)
         {
             UnitSystem unitSystem = UnitSystem.GetCached("en-US");

--- a/UnitsNet.Tests/CustomCode/ParseTests.cs
+++ b/UnitsNet.Tests/CustomCode/ParseTests.cs
@@ -165,26 +165,50 @@ namespace UnitsNet.Tests.CustomCode
         }
 
         [Theory]
-        [InlineData("10 m^2", true)]
-        public void TryParseLengthUnitAbbreviationWithNumbers(string s, bool expected)
+        [InlineData("!")]
+        [InlineData("@")]
+        [InlineData("#")]
+        [InlineData("$")]
+        [InlineData("%")]
+        [InlineData("^")]
+        [InlineData("&")]
+        [InlineData("*")]
+        [InlineData("-")]
+        [InlineData("_")]
+        [InlineData("?")]
+        [InlineData("123")]
+        public void TryParseLengthUnitAbbreviation(string s)
         {
-            UnitSystem.ClearCache();
             UnitSystem unitSystem = UnitSystem.GetCached("en-US");
-            unitSystem.MapUnitToAbbreviation(UnitsNet.Units.LengthUnit.Meter, "m^2");
-            Length result;
-            bool actual = Length.TryParse(s, out result);
-            Assert.Equal(expected, actual);
+            string abbrev = $"m{s}s";
+            unitSystem.MapUnitToAbbreviation(UnitsNet.Units.LengthUnit.Meter, abbrev);
+            UnitsNet.Units.LengthUnit result;
+            bool actual = unitSystem.TryParse<UnitsNet.Units.LengthUnit>(abbrev, out result);
+            Assert.Equal(true, actual);
+            Assert.Equal(UnitsNet.Units.LengthUnit.Meter, result);
         }
 
         [Theory]
-        [InlineData("10 m2")]
-        public void ParseLengthUnitAbbreviationWithNumbers(string s)
+        [InlineData("!")]
+        [InlineData("@")]
+        [InlineData("#")]
+        [InlineData("$")]
+        [InlineData("%")]
+        [InlineData("^")]
+        [InlineData("&")]
+        [InlineData("*")]
+        [InlineData("-")]
+        [InlineData("_")]
+        [InlineData("?")]
+        [InlineData("123")]
+        public void TryParseLengthUnitAbbreviationWithNumbers(string s)
         {
-            UnitSystem.ClearCache();
             UnitSystem unitSystem = UnitSystem.GetCached("en-US");
-            unitSystem.MapUnitToAbbreviation(UnitsNet.Units.LengthUnit.Meter, "m2");
-            Length actual = Length.Parse(s);
-            Assert.Equal(new Length(10), actual);
+            string abbrev = $"m{s}s";
+            unitSystem.MapUnitToAbbreviation(UnitsNet.Units.LengthUnit.Meter, abbrev);
+            bool actual = Length.TryParse($"10 {abbrev}", out Length result);
+            Assert.Equal(true, actual);
+            Assert.Equal(Length.FromMeters(10d), result);
         }
 
         private static string AssertExceptionAndGetFullTypeName(Action code)

--- a/UnitsNet.Tests/CustomCode/ParseTests.cs
+++ b/UnitsNet.Tests/CustomCode/ParseTests.cs
@@ -164,6 +164,29 @@ namespace UnitsNet.Tests.CustomCode
             Assert.Equal(expected, actual);
         }
 
+        [Theory]
+        [InlineData("10 m^2", true)]
+        public void TryParseLengthUnitAbbreviationWithNumbers(string s, bool expected)
+        {
+            UnitSystem.ClearCache();
+            UnitSystem unitSystem = UnitSystem.GetCached("en-US");
+            unitSystem.MapUnitToAbbreviation(UnitsNet.Units.LengthUnit.Meter, "m^2");
+            Length result;
+            bool actual = Length.TryParse(s, out result);
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
+        [InlineData("10 m2")]
+        public void ParseLengthUnitAbbreviationWithNumbers(string s)
+        {
+            UnitSystem.ClearCache();
+            UnitSystem unitSystem = UnitSystem.GetCached("en-US");
+            unitSystem.MapUnitToAbbreviation(UnitsNet.Units.LengthUnit.Meter, "m2");
+            Length actual = Length.Parse(s);
+            Assert.Equal(new Length(10), actual);
+        }
+
         private static string AssertExceptionAndGetFullTypeName(Action code)
         {
             var exception = Assert.ThrowsAny<Exception>(code);

--- a/UnitsNet.Tests/CustomCode/ParseTests.cs
+++ b/UnitsNet.Tests/CustomCode/ParseTests.cs
@@ -177,8 +177,8 @@ namespace UnitsNet.Tests.CustomCode
         [InlineData("_")]
         [InlineData("?")]
         [InlineData("123")]
-        [InlineData("od to")]
-        public void TryParseLengthUnitAbbreviation(string s)
+        [InlineData(" ")]
+        public void TryParseLengthUnitAbbreviationSpecialCharacters(string s)
         {
             UnitSystem unitSystem = UnitSystem.GetCached("en-US");
             string abbrev = $"m{s}s";
@@ -202,8 +202,8 @@ namespace UnitsNet.Tests.CustomCode
         [InlineData("_")]
         [InlineData("?")]
         [InlineData("123")]
-        [InlineData("od to")]
-        public void TryParseLengthUnitAbbreviationWithNumbers(string s)
+        [InlineData(" ")]
+        public void TryParseLengthSpecialCharacters(string s)
         {
             UnitSystem unitSystem = UnitSystem.GetCached("en-US");
             string abbrev = $"m{s}s";

--- a/UnitsNet/CustomCode/UnitParser.cs
+++ b/UnitsNet/CustomCode/UnitParser.cs
@@ -69,8 +69,7 @@ namespace UnitsNet
                     unitAbbreviations[i] = unitAbbreviations[i].Replace(specialCharacter, @"\" + specialCharacter);
                 }
             }
-            // Technically, any number of matches are possible in the correct order ("10yardmmft")
-            string unitsRegex = $"({String.Join(")?(", unitAbbreviations)})?";
+            string unitsRegex = $"({String.Join("|", unitAbbreviations)})";
 
             string regexString = string.Format(@"(?:\s*(?<value>[-+]?{0}{1}{2}{3})?{4}{5}",
                 numRegex, // capture base (integral) Quantity value
@@ -92,7 +91,7 @@ namespace UnitsNet
 
         /// <summary>
         ///     Parse a string given a particular regular expression.
-        /// </summary>
+        /// </summary>  
         /// <exception cref="UnitsNetException">Error parsing string.</exception>
         private static List<TUnit> ParseWithRegex<TUnit>(string regexString, string str, ParseUnit<TUnit> parseUnit,
             IFormatProvider formatProvider = null)

--- a/UnitsNet/CustomCode/UnitParser.cs
+++ b/UnitsNet/CustomCode/UnitParser.cs
@@ -34,7 +34,7 @@ namespace UnitsNet
     internal static class UnitParser
     {
         [SuppressMessage("ReSharper", "UseStringInterpolation")]
-        internal static TUnit ParseUnit<TQuantity, TUnit>([NotNull] string str,
+        internal static TUnit ParseUnit<TQuantityEnum, TUnit>([NotNull] string str,
             [CanBeNull] IFormatProvider formatProvider,
             [NotNull] ParseUnit<TUnit> parseUnit,
             [NotNull] Func<TUnit, TUnit, TUnit> add)
@@ -55,7 +55,7 @@ namespace UnitsNet
             const string exponentialRegex = @"(?:[eE][-+]?\d+)?)";
 
             string[] unitAbbreviations = UnitSystem.GetCached(formatProvider)
-                .GetAllAbbreviations(typeof(TQuantity))
+                .GetAllAbbreviations(typeof(TQuantityEnum))
                 .OrderByDescending(s => s.Length)       // Important to order by length -- if "m" is before "mm" and the input is "mm", it will match just "m" and throw invalid string error
                 .Select(Regex.Escape)                   // Escape special regex characters
                 .ToArray();

--- a/UnitsNet/CustomCode/UnitParser.cs
+++ b/UnitsNet/CustomCode/UnitParser.cs
@@ -29,15 +29,15 @@ using JetBrains.Annotations;
 
 namespace UnitsNet
 {
-    internal delegate TUnit ParseUnit<out TUnit>(string value, string unit, IFormatProvider formatProvider = null);
+    internal delegate TQuantity ParseUnit<out TQuantity>(string value, string unit, IFormatProvider formatProvider = null);
 
     internal static class UnitParser
     {
         [SuppressMessage("ReSharper", "UseStringInterpolation")]
-        internal static TUnit ParseUnit<TQuantityEnum, TUnit>([NotNull] string str,
+        internal static TQuantity ParseUnit<TQuantityEnum, TQuantity>([NotNull] string str,
             [CanBeNull] IFormatProvider formatProvider,
-            [NotNull] ParseUnit<TUnit> parseUnit,
-            [NotNull] Func<TUnit, TUnit, TUnit> add)
+            [NotNull] ParseUnit<TQuantity> parseUnit,
+            [NotNull] Func<TQuantity, TQuantity, TQuantity> add)
         {
             if (str == null) throw new ArgumentNullException(nameof(str));
             if (parseUnit == null) throw new ArgumentNullException(nameof(parseUnit));
@@ -70,7 +70,7 @@ namespace UnitsNet
                 @"(and)?,?", // allow "and" & "," separators between quantities
                 @"(?<invalid>[a-z]*)?"); // capture invalid input
 
-            List<TUnit> quantities = ParseWithRegex(regexString, str, parseUnit, formatProvider);
+            List<TQuantity> quantities = ParseWithRegex(regexString, str, parseUnit, formatProvider);
             if (quantities.Count == 0)
             {
                 throw new ArgumentException(
@@ -84,12 +84,12 @@ namespace UnitsNet
         ///     Parse a string given a particular regular expression.
         /// </summary>  
         /// <exception cref="UnitsNetException">Error parsing string.</exception>
-        private static List<TUnit> ParseWithRegex<TUnit>(string regexString, string str, ParseUnit<TUnit> parseUnit,
+        private static List<TQuantity> ParseWithRegex<TQuantity>(string regexString, string str, ParseUnit<TQuantity> parseUnit,
             IFormatProvider formatProvider = null)
         {
             var regex = new Regex(regexString);
             MatchCollection matches = regex.Matches(str.Trim());
-            var converted = new List<TUnit>();
+            var converted = new List<TQuantity>();
 
             foreach (Match match in matches)
             {

--- a/UnitsNet/CustomCode/UnitParser.cs
+++ b/UnitsNet/CustomCode/UnitParser.cs
@@ -55,8 +55,6 @@ namespace UnitsNet
 
             const string exponentialRegex = @"(?:[eE][-+]?\d+)?)";
 
-            // Special regex characters that need escaping
-            string[] regexSpecialCharacters = {"$","^","*","?"};
             string[] unitAbbreviations = UnitSystem.GetCached(formatProvider)
                 .GetAllAbbreviations(unitType)
                 .OrderByDescending(s => s.Length) // Important to order by length -- if "m" is before "mm" and the input is "mm", it will match just "m" and throw invalid string error
@@ -64,10 +62,7 @@ namespace UnitsNet
             // Escape special regex characters
             for (int i = 0; i < unitAbbreviations.Length; i++)
             {
-                foreach (string specialCharacter in regexSpecialCharacters)
-                {
-                    unitAbbreviations[i] = unitAbbreviations[i].Replace(specialCharacter, @"\" + specialCharacter);
-                }
+                unitAbbreviations[i] = Regex.Escape(unitAbbreviations[i]);
             }
             string unitsRegex = $"({String.Join("|", unitAbbreviations)})";
 
@@ -75,7 +70,7 @@ namespace UnitsNet
                 numRegex, // capture base (integral) Quantity value
                 exponentialRegex, // capture exponential (if any), end of Quantity capturing
                 @"\s?", // ignore whitespace (allows both "1kg", "1 kg")
-                $@"(?<unit>{unitsRegex})", // capture Unit (non-whitespace) input
+                $@"(?<unit>{unitsRegex})", // capture Unit by list of abbreviations
                 @"(and)?,?", // allow "and" & "," separators between quantities
                 @"(?<invalid>[a-z]*)?"); // capture invalid input
 

--- a/UnitsNet/CustomCode/UnitParser.cs
+++ b/UnitsNet/CustomCode/UnitParser.cs
@@ -34,11 +34,10 @@ namespace UnitsNet
     internal static class UnitParser
     {
         [SuppressMessage("ReSharper", "UseStringInterpolation")]
-        internal static TUnit ParseUnit<TUnit>([NotNull] string str,
+        internal static TUnit ParseUnit<TQuantity, TUnit>([NotNull] string str,
             [CanBeNull] IFormatProvider formatProvider,
             [NotNull] ParseUnit<TUnit> parseUnit,
-            [NotNull] Func<TUnit, TUnit, TUnit> add,
-            Type unitType)
+            [NotNull] Func<TUnit, TUnit, TUnit> add)
         {
             if (str == null) throw new ArgumentNullException(nameof(str));
             if (parseUnit == null) throw new ArgumentNullException(nameof(parseUnit));
@@ -56,7 +55,7 @@ namespace UnitsNet
             const string exponentialRegex = @"(?:[eE][-+]?\d+)?)";
 
             string[] unitAbbreviations = UnitSystem.GetCached(formatProvider)
-                .GetAllAbbreviations(unitType)
+                .GetAllAbbreviations(typeof(TQuantity))
                 .OrderByDescending(s => s.Length) // Important to order by length -- if "m" is before "mm" and the input is "mm", it will match just "m" and throw invalid string error
                 .ToArray();
             // Escape special regex characters

--- a/UnitsNet/CustomCode/UnitParser.cs
+++ b/UnitsNet/CustomCode/UnitParser.cs
@@ -56,13 +56,10 @@ namespace UnitsNet
 
             string[] unitAbbreviations = UnitSystem.GetCached(formatProvider)
                 .GetAllAbbreviations(typeof(TQuantity))
-                .OrderByDescending(s => s.Length) // Important to order by length -- if "m" is before "mm" and the input is "mm", it will match just "m" and throw invalid string error
+                .OrderByDescending(s => s.Length)       // Important to order by length -- if "m" is before "mm" and the input is "mm", it will match just "m" and throw invalid string error
+                .Select(Regex.Escape)                   // Escape special regex characters
                 .ToArray();
-            // Escape special regex characters
-            for (int i = 0; i < unitAbbreviations.Length; i++)
-            {
-                unitAbbreviations[i] = Regex.Escape(unitAbbreviations[i]);
-            }
+            
             string unitsRegex = $"({String.Join("|", unitAbbreviations)})";
 
             string regexString = string.Format(@"(?:\s*(?<value>[-+]?{0}{1}{2}{3})?{4}{5}",

--- a/UnitsNet/CustomCode/UnitSystem.cs
+++ b/UnitsNet/CustomCode/UnitSystem.cs
@@ -459,11 +459,7 @@ namespace UnitsNet
 
             if (_unitTypeToUnitValueToAbbrevs.TryGetValue(unitType, out unitValueToAbbrevs))
             {
-                foreach (var item in unitValueToAbbrevs)
-                {
-                    abbrevs.AddRange(item.Value);
-                }
-                return abbrevs.ToArray();
+                return unitValueToAbbrevs.Values.SelectMany(x => x).ToArray();
             }
 
             // Fall back to default culture

--- a/UnitsNet/CustomCode/UnitSystem.cs
+++ b/UnitsNet/CustomCode/UnitSystem.cs
@@ -411,6 +411,33 @@ namespace UnitsNet
                 : GetCached(FallbackCulture).GetAllAbbreviations(unitType, unitValue);
         }
 
+        /// <summary>
+        ///     Get all abbreviations for unit.
+        /// </summary>
+        /// <param name="unitType">Enum type for unit.</param>
+        /// <param name="unitValue">Enum value for unit.</param>
+        /// <returns>Unit abbreviations associated with unit.</returns>
+        [PublicAPI]
+        public string[] GetAllAbbreviations(Type unitType)
+        {
+            Dictionary<int, List<string>> unitValueToAbbrevs;
+            List<string> abbrevs = new List<string>();
+
+            if (_unitTypeToUnitValueToAbbrevs.TryGetValue(unitType, out unitValueToAbbrevs))
+            {
+                foreach (var item in unitValueToAbbrevs)
+                {
+                    abbrevs.AddRange(item.Value);
+                }
+            }
+            return abbrevs.ToArray();
+
+            // Fall back to default culture
+            // return IsFallbackCulture
+            //     ? new[] {$"(no abbreviation for {unitType.Name} with numeric value {unitValue})"}
+            //     : GetCached(FallbackCulture).GetAllAbbreviations(unitType, unitValue);
+        }
+
         private void LoadDefaultAbbreviatons([NotNull] IFormatProvider culture)
         {
             foreach (UnitLocalization localization in DefaultLocalizations)

--- a/UnitsNet/CustomCode/UnitSystem.cs
+++ b/UnitsNet/CustomCode/UnitSystem.cs
@@ -472,7 +472,7 @@ namespace UnitsNet
                 : GetCached(FallbackCulture).GetAllAbbreviations(unitType);
         }
 
-        private void LoadDefaultAbbreviatons([NotNull] IFormatProvider culture)
+        private void LoadDefaultAbbreviations([NotNull] IFormatProvider culture)
         {
             foreach (UnitLocalization localization in DefaultLocalizations)
             {

--- a/UnitsNet/CustomCode/UnitSystem.cs
+++ b/UnitsNet/CustomCode/UnitSystem.cs
@@ -429,13 +429,13 @@ namespace UnitsNet
                 {
                     abbrevs.AddRange(item.Value);
                 }
+                return abbrevs.ToArray();
             }
-            return abbrevs.ToArray();
 
             // Fall back to default culture
-            // return IsFallbackCulture
-            //     ? new[] {$"(no abbreviation for {unitType.Name} with numeric value {unitValue})"}
-            //     : GetCached(FallbackCulture).GetAllAbbreviations(unitType, unitValue);
+            return IsFallbackCulture
+                ? new[] {$"(no abbreviations for {unitType.Name})"}
+                : GetCached(FallbackCulture).GetAllAbbreviations(unitType);
         }
 
         private void LoadDefaultAbbreviatons([NotNull] IFormatProvider culture)

--- a/UnitsNet/CustomCode/UnitSystem.cs
+++ b/UnitsNet/CustomCode/UnitSystem.cs
@@ -455,8 +455,6 @@ namespace UnitsNet
         public string[] GetAllAbbreviations(Type unitType)
         {
             Dictionary<int, List<string>> unitValueToAbbrevs;
-            List<string> abbrevs = new List<string>();
-
             if (_unitTypeToUnitValueToAbbrevs.TryGetValue(unitType, out unitValueToAbbrevs))
             {
                 return unitValueToAbbrevs.Values.SelectMany(x => x).ToArray();

--- a/UnitsNet/GeneratedCode/UnitClasses/Acceleration.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/Acceleration.g.cs
@@ -635,13 +635,13 @@ namespace UnitsNet
 #else
             IFormatProvider formatProvider = culture;
 #endif
-            return UnitParser.ParseUnit<Acceleration>(str, formatProvider,
+            return UnitParser.ParseUnit<AccelerationUnit, Acceleration>(str, formatProvider,
                 delegate(string value, string unit, IFormatProvider formatProvider2)
                 {
                     double parsedValue = double.Parse(value, formatProvider2);
                     AccelerationUnit parsedUnit = ParseUnit(unit, formatProvider2);
                     return From(parsedValue, parsedUnit);
-                }, (x, y) => FromMeterPerSecondSquared(x.MeterPerSecondSquared + y.MeterPerSecondSquared), typeof(AccelerationUnit));
+                }, (x, y) => FromMeterPerSecondSquared(x.MeterPerSecondSquared + y.MeterPerSecondSquared));
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/UnitClasses/Acceleration.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/Acceleration.g.cs
@@ -641,7 +641,7 @@ namespace UnitsNet
                     double parsedValue = double.Parse(value, formatProvider2);
                     AccelerationUnit parsedUnit = ParseUnit(unit, formatProvider2);
                     return From(parsedValue, parsedUnit);
-                }, (x, y) => FromMeterPerSecondSquared(x.MeterPerSecondSquared + y.MeterPerSecondSquared));
+                }, (x, y) => FromMeterPerSecondSquared(x.MeterPerSecondSquared + y.MeterPerSecondSquared), typeof(AccelerationUnit));
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/UnitClasses/AmplitudeRatio.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/AmplitudeRatio.g.cs
@@ -538,7 +538,7 @@ namespace UnitsNet
                     double parsedValue = double.Parse(value, formatProvider2);
                     AmplitudeRatioUnit parsedUnit = ParseUnit(unit, formatProvider2);
                     return From(parsedValue, parsedUnit);
-                }, (x, y) => FromDecibelVolts(x.DecibelVolts + y.DecibelVolts));
+                }, (x, y) => FromDecibelVolts(x.DecibelVolts + y.DecibelVolts), typeof(AmplitudeRatioUnit));
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/UnitClasses/AmplitudeRatio.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/AmplitudeRatio.g.cs
@@ -532,13 +532,13 @@ namespace UnitsNet
 #else
             IFormatProvider formatProvider = culture;
 #endif
-            return UnitParser.ParseUnit<AmplitudeRatio>(str, formatProvider,
+            return UnitParser.ParseUnit<AmplitudeRatioUnit, AmplitudeRatio>(str, formatProvider,
                 delegate(string value, string unit, IFormatProvider formatProvider2)
                 {
                     double parsedValue = double.Parse(value, formatProvider2);
                     AmplitudeRatioUnit parsedUnit = ParseUnit(unit, formatProvider2);
                     return From(parsedValue, parsedUnit);
-                }, (x, y) => FromDecibelVolts(x.DecibelVolts + y.DecibelVolts), typeof(AmplitudeRatioUnit));
+                }, (x, y) => FromDecibelVolts(x.DecibelVolts + y.DecibelVolts));
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/UnitClasses/Angle.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/Angle.g.cs
@@ -863,7 +863,7 @@ namespace UnitsNet
                     double parsedValue = double.Parse(value, formatProvider2);
                     AngleUnit parsedUnit = ParseUnit(unit, formatProvider2);
                     return From(parsedValue, parsedUnit);
-                }, (x, y) => FromDegrees(x.Degrees + y.Degrees));
+                }, (x, y) => FromDegrees(x.Degrees + y.Degrees), typeof(AngleUnit));
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/UnitClasses/Angle.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/Angle.g.cs
@@ -857,13 +857,13 @@ namespace UnitsNet
 #else
             IFormatProvider formatProvider = culture;
 #endif
-            return UnitParser.ParseUnit<Angle>(str, formatProvider,
+            return UnitParser.ParseUnit<AngleUnit, Angle>(str, formatProvider,
                 delegate(string value, string unit, IFormatProvider formatProvider2)
                 {
                     double parsedValue = double.Parse(value, formatProvider2);
                     AngleUnit parsedUnit = ParseUnit(unit, formatProvider2);
                     return From(parsedValue, parsedUnit);
-                }, (x, y) => FromDegrees(x.Degrees + y.Degrees), typeof(AngleUnit));
+                }, (x, y) => FromDegrees(x.Degrees + y.Degrees));
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/UnitClasses/ApparentPower.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/ApparentPower.g.cs
@@ -493,7 +493,7 @@ namespace UnitsNet
                     double parsedValue = double.Parse(value, formatProvider2);
                     ApparentPowerUnit parsedUnit = ParseUnit(unit, formatProvider2);
                     return From(parsedValue, parsedUnit);
-                }, (x, y) => FromVoltamperes(x.Voltamperes + y.Voltamperes));
+                }, (x, y) => FromVoltamperes(x.Voltamperes + y.Voltamperes), typeof(ApparentPowerUnit));
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/UnitClasses/ApparentPower.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/ApparentPower.g.cs
@@ -487,13 +487,13 @@ namespace UnitsNet
 #else
             IFormatProvider formatProvider = culture;
 #endif
-            return UnitParser.ParseUnit<ApparentPower>(str, formatProvider,
+            return UnitParser.ParseUnit<ApparentPowerUnit, ApparentPower>(str, formatProvider,
                 delegate(string value, string unit, IFormatProvider formatProvider2)
                 {
                     double parsedValue = double.Parse(value, formatProvider2);
                     ApparentPowerUnit parsedUnit = ParseUnit(unit, formatProvider2);
                     return From(parsedValue, parsedUnit);
-                }, (x, y) => FromVoltamperes(x.Voltamperes + y.Voltamperes), typeof(ApparentPowerUnit));
+                }, (x, y) => FromVoltamperes(x.Voltamperes + y.Voltamperes));
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/UnitClasses/Area.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/Area.g.cs
@@ -820,13 +820,13 @@ namespace UnitsNet
 #else
             IFormatProvider formatProvider = culture;
 #endif
-            return UnitParser.ParseUnit<Area>(str, formatProvider,
+            return UnitParser.ParseUnit<AreaUnit, Area>(str, formatProvider,
                 delegate(string value, string unit, IFormatProvider formatProvider2)
                 {
                     double parsedValue = double.Parse(value, formatProvider2);
                     AreaUnit parsedUnit = ParseUnit(unit, formatProvider2);
                     return From(parsedValue, parsedUnit);
-                }, (x, y) => FromSquareMeters(x.SquareMeters + y.SquareMeters), typeof(AreaUnit));
+                }, (x, y) => FromSquareMeters(x.SquareMeters + y.SquareMeters));
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/UnitClasses/Area.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/Area.g.cs
@@ -826,7 +826,7 @@ namespace UnitsNet
                     double parsedValue = double.Parse(value, formatProvider2);
                     AreaUnit parsedUnit = ParseUnit(unit, formatProvider2);
                     return From(parsedValue, parsedUnit);
-                }, (x, y) => FromSquareMeters(x.SquareMeters + y.SquareMeters));
+                }, (x, y) => FromSquareMeters(x.SquareMeters + y.SquareMeters), typeof(AreaUnit));
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/UnitClasses/BrakeSpecificFuelConsumption.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/BrakeSpecificFuelConsumption.g.cs
@@ -493,7 +493,7 @@ namespace UnitsNet
                     double parsedValue = double.Parse(value, formatProvider2);
                     BrakeSpecificFuelConsumptionUnit parsedUnit = ParseUnit(unit, formatProvider2);
                     return From(parsedValue, parsedUnit);
-                }, (x, y) => FromKilogramsPerJoule(x.KilogramsPerJoule + y.KilogramsPerJoule));
+                }, (x, y) => FromKilogramsPerJoule(x.KilogramsPerJoule + y.KilogramsPerJoule), typeof(BrakeSpecificFuelConsumptionUnit));
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/UnitClasses/BrakeSpecificFuelConsumption.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/BrakeSpecificFuelConsumption.g.cs
@@ -487,13 +487,13 @@ namespace UnitsNet
 #else
             IFormatProvider formatProvider = culture;
 #endif
-            return UnitParser.ParseUnit<BrakeSpecificFuelConsumption>(str, formatProvider,
+            return UnitParser.ParseUnit<BrakeSpecificFuelConsumptionUnit, BrakeSpecificFuelConsumption>(str, formatProvider,
                 delegate(string value, string unit, IFormatProvider formatProvider2)
                 {
                     double parsedValue = double.Parse(value, formatProvider2);
                     BrakeSpecificFuelConsumptionUnit parsedUnit = ParseUnit(unit, formatProvider2);
                     return From(parsedValue, parsedUnit);
-                }, (x, y) => FromKilogramsPerJoule(x.KilogramsPerJoule + y.KilogramsPerJoule), typeof(BrakeSpecificFuelConsumptionUnit));
+                }, (x, y) => FromKilogramsPerJoule(x.KilogramsPerJoule + y.KilogramsPerJoule));
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/UnitClasses/Density.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/Density.g.cs
@@ -1671,13 +1671,13 @@ namespace UnitsNet
 #else
             IFormatProvider formatProvider = culture;
 #endif
-            return UnitParser.ParseUnit<Density>(str, formatProvider,
+            return UnitParser.ParseUnit<DensityUnit, Density>(str, formatProvider,
                 delegate(string value, string unit, IFormatProvider formatProvider2)
                 {
                     double parsedValue = double.Parse(value, formatProvider2);
                     DensityUnit parsedUnit = ParseUnit(unit, formatProvider2);
                     return From(parsedValue, parsedUnit);
-                }, (x, y) => FromKilogramsPerCubicMeter(x.KilogramsPerCubicMeter + y.KilogramsPerCubicMeter), typeof(DensityUnit));
+                }, (x, y) => FromKilogramsPerCubicMeter(x.KilogramsPerCubicMeter + y.KilogramsPerCubicMeter));
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/UnitClasses/Density.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/Density.g.cs
@@ -1677,7 +1677,7 @@ namespace UnitsNet
                     double parsedValue = double.Parse(value, formatProvider2);
                     DensityUnit parsedUnit = ParseUnit(unit, formatProvider2);
                     return From(parsedValue, parsedUnit);
-                }, (x, y) => FromKilogramsPerCubicMeter(x.KilogramsPerCubicMeter + y.KilogramsPerCubicMeter));
+                }, (x, y) => FromKilogramsPerCubicMeter(x.KilogramsPerCubicMeter + y.KilogramsPerCubicMeter), typeof(DensityUnit));
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/UnitClasses/Duration.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/Duration.g.cs
@@ -752,7 +752,7 @@ namespace UnitsNet
                     double parsedValue = double.Parse(value, formatProvider2);
                     DurationUnit parsedUnit = ParseUnit(unit, formatProvider2);
                     return From(parsedValue, parsedUnit);
-                }, (x, y) => FromSeconds(x.Seconds + y.Seconds));
+                }, (x, y) => FromSeconds(x.Seconds + y.Seconds), typeof(DurationUnit));
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/UnitClasses/Duration.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/Duration.g.cs
@@ -746,13 +746,13 @@ namespace UnitsNet
 #else
             IFormatProvider formatProvider = culture;
 #endif
-            return UnitParser.ParseUnit<Duration>(str, formatProvider,
+            return UnitParser.ParseUnit<DurationUnit, Duration>(str, formatProvider,
                 delegate(string value, string unit, IFormatProvider formatProvider2)
                 {
                     double parsedValue = double.Parse(value, formatProvider2);
                     DurationUnit parsedUnit = ParseUnit(unit, formatProvider2);
                     return From(parsedValue, parsedUnit);
-                }, (x, y) => FromSeconds(x.Seconds + y.Seconds), typeof(DurationUnit));
+                }, (x, y) => FromSeconds(x.Seconds + y.Seconds));
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/UnitClasses/DynamicViscosity.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/DynamicViscosity.g.cs
@@ -561,13 +561,13 @@ namespace UnitsNet
 #else
             IFormatProvider formatProvider = culture;
 #endif
-            return UnitParser.ParseUnit<DynamicViscosity>(str, formatProvider,
+            return UnitParser.ParseUnit<DynamicViscosityUnit, DynamicViscosity>(str, formatProvider,
                 delegate(string value, string unit, IFormatProvider formatProvider2)
                 {
                     double parsedValue = double.Parse(value, formatProvider2);
                     DynamicViscosityUnit parsedUnit = ParseUnit(unit, formatProvider2);
                     return From(parsedValue, parsedUnit);
-                }, (x, y) => FromNewtonSecondsPerMeterSquared(x.NewtonSecondsPerMeterSquared + y.NewtonSecondsPerMeterSquared), typeof(DynamicViscosityUnit));
+                }, (x, y) => FromNewtonSecondsPerMeterSquared(x.NewtonSecondsPerMeterSquared + y.NewtonSecondsPerMeterSquared));
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/UnitClasses/DynamicViscosity.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/DynamicViscosity.g.cs
@@ -567,7 +567,7 @@ namespace UnitsNet
                     double parsedValue = double.Parse(value, formatProvider2);
                     DynamicViscosityUnit parsedUnit = ParseUnit(unit, formatProvider2);
                     return From(parsedValue, parsedUnit);
-                }, (x, y) => FromNewtonSecondsPerMeterSquared(x.NewtonSecondsPerMeterSquared + y.NewtonSecondsPerMeterSquared));
+                }, (x, y) => FromNewtonSecondsPerMeterSquared(x.NewtonSecondsPerMeterSquared + y.NewtonSecondsPerMeterSquared), typeof(DynamicViscosityUnit));
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/UnitClasses/ElectricAdmittance.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/ElectricAdmittance.g.cs
@@ -530,7 +530,7 @@ namespace UnitsNet
                     double parsedValue = double.Parse(value, formatProvider2);
                     ElectricAdmittanceUnit parsedUnit = ParseUnit(unit, formatProvider2);
                     return From(parsedValue, parsedUnit);
-                }, (x, y) => FromSiemens(x.Siemens + y.Siemens));
+                }, (x, y) => FromSiemens(x.Siemens + y.Siemens), typeof(ElectricAdmittanceUnit));
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/UnitClasses/ElectricAdmittance.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/ElectricAdmittance.g.cs
@@ -524,13 +524,13 @@ namespace UnitsNet
 #else
             IFormatProvider formatProvider = culture;
 #endif
-            return UnitParser.ParseUnit<ElectricAdmittance>(str, formatProvider,
+            return UnitParser.ParseUnit<ElectricAdmittanceUnit, ElectricAdmittance>(str, formatProvider,
                 delegate(string value, string unit, IFormatProvider formatProvider2)
                 {
                     double parsedValue = double.Parse(value, formatProvider2);
                     ElectricAdmittanceUnit parsedUnit = ParseUnit(unit, formatProvider2);
                     return From(parsedValue, parsedUnit);
-                }, (x, y) => FromSiemens(x.Siemens + y.Siemens), typeof(ElectricAdmittanceUnit));
+                }, (x, y) => FromSiemens(x.Siemens + y.Siemens));
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/UnitClasses/ElectricCurrent.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/ElectricCurrent.g.cs
@@ -641,7 +641,7 @@ namespace UnitsNet
                     double parsedValue = double.Parse(value, formatProvider2);
                     ElectricCurrentUnit parsedUnit = ParseUnit(unit, formatProvider2);
                     return From(parsedValue, parsedUnit);
-                }, (x, y) => FromAmperes(x.Amperes + y.Amperes));
+                }, (x, y) => FromAmperes(x.Amperes + y.Amperes), typeof(ElectricCurrentUnit));
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/UnitClasses/ElectricCurrent.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/ElectricCurrent.g.cs
@@ -635,13 +635,13 @@ namespace UnitsNet
 #else
             IFormatProvider formatProvider = culture;
 #endif
-            return UnitParser.ParseUnit<ElectricCurrent>(str, formatProvider,
+            return UnitParser.ParseUnit<ElectricCurrentUnit, ElectricCurrent>(str, formatProvider,
                 delegate(string value, string unit, IFormatProvider formatProvider2)
                 {
                     double parsedValue = double.Parse(value, formatProvider2);
                     ElectricCurrentUnit parsedUnit = ParseUnit(unit, formatProvider2);
                     return From(parsedValue, parsedUnit);
-                }, (x, y) => FromAmperes(x.Amperes + y.Amperes), typeof(ElectricCurrentUnit));
+                }, (x, y) => FromAmperes(x.Amperes + y.Amperes));
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/UnitClasses/ElectricPotential.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/ElectricPotential.g.cs
@@ -561,13 +561,13 @@ namespace UnitsNet
 #else
             IFormatProvider formatProvider = culture;
 #endif
-            return UnitParser.ParseUnit<ElectricPotential>(str, formatProvider,
+            return UnitParser.ParseUnit<ElectricPotentialUnit, ElectricPotential>(str, formatProvider,
                 delegate(string value, string unit, IFormatProvider formatProvider2)
                 {
                     double parsedValue = double.Parse(value, formatProvider2);
                     ElectricPotentialUnit parsedUnit = ParseUnit(unit, formatProvider2);
                     return From(parsedValue, parsedUnit);
-                }, (x, y) => FromVolts(x.Volts + y.Volts), typeof(ElectricPotentialUnit));
+                }, (x, y) => FromVolts(x.Volts + y.Volts));
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/UnitClasses/ElectricPotential.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/ElectricPotential.g.cs
@@ -567,7 +567,7 @@ namespace UnitsNet
                     double parsedValue = double.Parse(value, formatProvider2);
                     ElectricPotentialUnit parsedUnit = ParseUnit(unit, formatProvider2);
                     return From(parsedValue, parsedUnit);
-                }, (x, y) => FromVolts(x.Volts + y.Volts));
+                }, (x, y) => FromVolts(x.Volts + y.Volts), typeof(ElectricPotentialUnit));
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/UnitClasses/ElectricPotentialAc.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/ElectricPotentialAc.g.cs
@@ -561,13 +561,13 @@ namespace UnitsNet
 #else
             IFormatProvider formatProvider = culture;
 #endif
-            return UnitParser.ParseUnit<ElectricPotentialAc>(str, formatProvider,
+            return UnitParser.ParseUnit<ElectricPotentialAcUnit, ElectricPotentialAc>(str, formatProvider,
                 delegate(string value, string unit, IFormatProvider formatProvider2)
                 {
                     double parsedValue = double.Parse(value, formatProvider2);
                     ElectricPotentialAcUnit parsedUnit = ParseUnit(unit, formatProvider2);
                     return From(parsedValue, parsedUnit);
-                }, (x, y) => FromVoltsAc(x.VoltsAc + y.VoltsAc), typeof(ElectricPotentialAcUnit));
+                }, (x, y) => FromVoltsAc(x.VoltsAc + y.VoltsAc));
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/UnitClasses/ElectricPotentialAc.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/ElectricPotentialAc.g.cs
@@ -567,7 +567,7 @@ namespace UnitsNet
                     double parsedValue = double.Parse(value, formatProvider2);
                     ElectricPotentialAcUnit parsedUnit = ParseUnit(unit, formatProvider2);
                     return From(parsedValue, parsedUnit);
-                }, (x, y) => FromVoltsAc(x.VoltsAc + y.VoltsAc));
+                }, (x, y) => FromVoltsAc(x.VoltsAc + y.VoltsAc), typeof(ElectricPotentialAcUnit));
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/UnitClasses/ElectricPotentialDc.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/ElectricPotentialDc.g.cs
@@ -567,7 +567,7 @@ namespace UnitsNet
                     double parsedValue = double.Parse(value, formatProvider2);
                     ElectricPotentialDcUnit parsedUnit = ParseUnit(unit, formatProvider2);
                     return From(parsedValue, parsedUnit);
-                }, (x, y) => FromVoltsDc(x.VoltsDc + y.VoltsDc));
+                }, (x, y) => FromVoltsDc(x.VoltsDc + y.VoltsDc), typeof(ElectricPotentialDcUnit));
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/UnitClasses/ElectricPotentialDc.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/ElectricPotentialDc.g.cs
@@ -561,13 +561,13 @@ namespace UnitsNet
 #else
             IFormatProvider formatProvider = culture;
 #endif
-            return UnitParser.ParseUnit<ElectricPotentialDc>(str, formatProvider,
+            return UnitParser.ParseUnit<ElectricPotentialDcUnit, ElectricPotentialDc>(str, formatProvider,
                 delegate(string value, string unit, IFormatProvider formatProvider2)
                 {
                     double parsedValue = double.Parse(value, formatProvider2);
                     ElectricPotentialDcUnit parsedUnit = ParseUnit(unit, formatProvider2);
                     return From(parsedValue, parsedUnit);
-                }, (x, y) => FromVoltsDc(x.VoltsDc + y.VoltsDc), typeof(ElectricPotentialDcUnit));
+                }, (x, y) => FromVoltsDc(x.VoltsDc + y.VoltsDc));
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/UnitClasses/ElectricResistance.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/ElectricResistance.g.cs
@@ -524,13 +524,13 @@ namespace UnitsNet
 #else
             IFormatProvider formatProvider = culture;
 #endif
-            return UnitParser.ParseUnit<ElectricResistance>(str, formatProvider,
+            return UnitParser.ParseUnit<ElectricResistanceUnit, ElectricResistance>(str, formatProvider,
                 delegate(string value, string unit, IFormatProvider formatProvider2)
                 {
                     double parsedValue = double.Parse(value, formatProvider2);
                     ElectricResistanceUnit parsedUnit = ParseUnit(unit, formatProvider2);
                     return From(parsedValue, parsedUnit);
-                }, (x, y) => FromOhms(x.Ohms + y.Ohms), typeof(ElectricResistanceUnit));
+                }, (x, y) => FromOhms(x.Ohms + y.Ohms));
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/UnitClasses/ElectricResistance.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/ElectricResistance.g.cs
@@ -530,7 +530,7 @@ namespace UnitsNet
                     double parsedValue = double.Parse(value, formatProvider2);
                     ElectricResistanceUnit parsedUnit = ParseUnit(unit, formatProvider2);
                     return From(parsedValue, parsedUnit);
-                }, (x, y) => FromOhms(x.Ohms + y.Ohms));
+                }, (x, y) => FromOhms(x.Ohms + y.Ohms), typeof(ElectricResistanceUnit));
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/UnitClasses/Energy.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/Energy.g.cs
@@ -857,13 +857,13 @@ namespace UnitsNet
 #else
             IFormatProvider formatProvider = culture;
 #endif
-            return UnitParser.ParseUnit<Energy>(str, formatProvider,
+            return UnitParser.ParseUnit<EnergyUnit, Energy>(str, formatProvider,
                 delegate(string value, string unit, IFormatProvider formatProvider2)
                 {
                     double parsedValue = double.Parse(value, formatProvider2);
                     EnergyUnit parsedUnit = ParseUnit(unit, formatProvider2);
                     return From(parsedValue, parsedUnit);
-                }, (x, y) => FromJoules(x.Joules + y.Joules), typeof(EnergyUnit));
+                }, (x, y) => FromJoules(x.Joules + y.Joules));
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/UnitClasses/Energy.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/Energy.g.cs
@@ -863,7 +863,7 @@ namespace UnitsNet
                     double parsedValue = double.Parse(value, formatProvider2);
                     EnergyUnit parsedUnit = ParseUnit(unit, formatProvider2);
                     return From(parsedValue, parsedUnit);
-                }, (x, y) => FromJoules(x.Joules + y.Joules));
+                }, (x, y) => FromJoules(x.Joules + y.Joules), typeof(EnergyUnit));
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/UnitClasses/Flow.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/Flow.g.cs
@@ -974,7 +974,7 @@ namespace UnitsNet
                     double parsedValue = double.Parse(value, formatProvider2);
                     FlowUnit parsedUnit = ParseUnit(unit, formatProvider2);
                     return From(parsedValue, parsedUnit);
-                }, (x, y) => FromCubicMetersPerSecond(x.CubicMetersPerSecond + y.CubicMetersPerSecond));
+                }, (x, y) => FromCubicMetersPerSecond(x.CubicMetersPerSecond + y.CubicMetersPerSecond), typeof(FlowUnit));
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/UnitClasses/Flow.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/Flow.g.cs
@@ -968,13 +968,13 @@ namespace UnitsNet
 #else
             IFormatProvider formatProvider = culture;
 #endif
-            return UnitParser.ParseUnit<Flow>(str, formatProvider,
+            return UnitParser.ParseUnit<FlowUnit, Flow>(str, formatProvider,
                 delegate(string value, string unit, IFormatProvider formatProvider2)
                 {
                     double parsedValue = double.Parse(value, formatProvider2);
                     FlowUnit parsedUnit = ParseUnit(unit, formatProvider2);
                     return From(parsedValue, parsedUnit);
-                }, (x, y) => FromCubicMetersPerSecond(x.CubicMetersPerSecond + y.CubicMetersPerSecond), typeof(FlowUnit));
+                }, (x, y) => FromCubicMetersPerSecond(x.CubicMetersPerSecond + y.CubicMetersPerSecond));
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/UnitClasses/Force.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/Force.g.cs
@@ -709,13 +709,13 @@ namespace UnitsNet
 #else
             IFormatProvider formatProvider = culture;
 #endif
-            return UnitParser.ParseUnit<Force>(str, formatProvider,
+            return UnitParser.ParseUnit<ForceUnit, Force>(str, formatProvider,
                 delegate(string value, string unit, IFormatProvider formatProvider2)
                 {
                     double parsedValue = double.Parse(value, formatProvider2);
                     ForceUnit parsedUnit = ParseUnit(unit, formatProvider2);
                     return From(parsedValue, parsedUnit);
-                }, (x, y) => FromNewtons(x.Newtons + y.Newtons), typeof(ForceUnit));
+                }, (x, y) => FromNewtons(x.Newtons + y.Newtons));
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/UnitClasses/Force.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/Force.g.cs
@@ -715,7 +715,7 @@ namespace UnitsNet
                     double parsedValue = double.Parse(value, formatProvider2);
                     ForceUnit parsedUnit = ParseUnit(unit, formatProvider2);
                     return From(parsedValue, parsedUnit);
-                }, (x, y) => FromNewtons(x.Newtons + y.Newtons));
+                }, (x, y) => FromNewtons(x.Newtons + y.Newtons), typeof(ForceUnit));
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/UnitClasses/ForceChangeRate.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/ForceChangeRate.g.cs
@@ -783,13 +783,13 @@ namespace UnitsNet
 #else
             IFormatProvider formatProvider = culture;
 #endif
-            return UnitParser.ParseUnit<ForceChangeRate>(str, formatProvider,
+            return UnitParser.ParseUnit<ForceChangeRateUnit, ForceChangeRate>(str, formatProvider,
                 delegate(string value, string unit, IFormatProvider formatProvider2)
                 {
                     double parsedValue = double.Parse(value, formatProvider2);
                     ForceChangeRateUnit parsedUnit = ParseUnit(unit, formatProvider2);
                     return From(parsedValue, parsedUnit);
-                }, (x, y) => FromNewtonsPerSecond(x.NewtonsPerSecond + y.NewtonsPerSecond), typeof(ForceChangeRateUnit));
+                }, (x, y) => FromNewtonsPerSecond(x.NewtonsPerSecond + y.NewtonsPerSecond));
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/UnitClasses/ForceChangeRate.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/ForceChangeRate.g.cs
@@ -789,7 +789,7 @@ namespace UnitsNet
                     double parsedValue = double.Parse(value, formatProvider2);
                     ForceChangeRateUnit parsedUnit = ParseUnit(unit, formatProvider2);
                     return From(parsedValue, parsedUnit);
-                }, (x, y) => FromNewtonsPerSecond(x.NewtonsPerSecond + y.NewtonsPerSecond));
+                }, (x, y) => FromNewtonsPerSecond(x.NewtonsPerSecond + y.NewtonsPerSecond), typeof(ForceChangeRateUnit));
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/UnitClasses/ForcePerLength.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/ForcePerLength.g.cs
@@ -672,13 +672,13 @@ namespace UnitsNet
 #else
             IFormatProvider formatProvider = culture;
 #endif
-            return UnitParser.ParseUnit<ForcePerLength>(str, formatProvider,
+            return UnitParser.ParseUnit<ForcePerLengthUnit, ForcePerLength>(str, formatProvider,
                 delegate(string value, string unit, IFormatProvider formatProvider2)
                 {
                     double parsedValue = double.Parse(value, formatProvider2);
                     ForcePerLengthUnit parsedUnit = ParseUnit(unit, formatProvider2);
                     return From(parsedValue, parsedUnit);
-                }, (x, y) => FromNewtonsPerMeter(x.NewtonsPerMeter + y.NewtonsPerMeter), typeof(ForcePerLengthUnit));
+                }, (x, y) => FromNewtonsPerMeter(x.NewtonsPerMeter + y.NewtonsPerMeter));
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/UnitClasses/ForcePerLength.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/ForcePerLength.g.cs
@@ -678,7 +678,7 @@ namespace UnitsNet
                     double parsedValue = double.Parse(value, formatProvider2);
                     ForcePerLengthUnit parsedUnit = ParseUnit(unit, formatProvider2);
                     return From(parsedValue, parsedUnit);
-                }, (x, y) => FromNewtonsPerMeter(x.NewtonsPerMeter + y.NewtonsPerMeter));
+                }, (x, y) => FromNewtonsPerMeter(x.NewtonsPerMeter + y.NewtonsPerMeter), typeof(ForcePerLengthUnit));
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/UnitClasses/Frequency.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/Frequency.g.cs
@@ -678,7 +678,7 @@ namespace UnitsNet
                     double parsedValue = double.Parse(value, formatProvider2);
                     FrequencyUnit parsedUnit = ParseUnit(unit, formatProvider2);
                     return From(parsedValue, parsedUnit);
-                }, (x, y) => FromHertz(x.Hertz + y.Hertz));
+                }, (x, y) => FromHertz(x.Hertz + y.Hertz), typeof(FrequencyUnit));
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/UnitClasses/Frequency.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/Frequency.g.cs
@@ -672,13 +672,13 @@ namespace UnitsNet
 #else
             IFormatProvider formatProvider = culture;
 #endif
-            return UnitParser.ParseUnit<Frequency>(str, formatProvider,
+            return UnitParser.ParseUnit<FrequencyUnit, Frequency>(str, formatProvider,
                 delegate(string value, string unit, IFormatProvider formatProvider2)
                 {
                     double parsedValue = double.Parse(value, formatProvider2);
                     FrequencyUnit parsedUnit = ParseUnit(unit, formatProvider2);
                     return From(parsedValue, parsedUnit);
-                }, (x, y) => FromHertz(x.Hertz + y.Hertz), typeof(FrequencyUnit));
+                }, (x, y) => FromHertz(x.Hertz + y.Hertz));
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/UnitClasses/Information.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/Information.g.cs
@@ -1344,7 +1344,7 @@ namespace UnitsNet
                     double parsedValue = double.Parse(value, formatProvider2);
                     InformationUnit parsedUnit = ParseUnit(unit, formatProvider2);
                     return From(parsedValue, parsedUnit);
-                }, (x, y) => FromBits(x.Bits + y.Bits));
+                }, (x, y) => FromBits(x.Bits + y.Bits), typeof(InformationUnit));
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/UnitClasses/Information.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/Information.g.cs
@@ -1338,13 +1338,13 @@ namespace UnitsNet
 #else
             IFormatProvider formatProvider = culture;
 #endif
-            return UnitParser.ParseUnit<Information>(str, formatProvider,
+            return UnitParser.ParseUnit<InformationUnit, Information>(str, formatProvider,
                 delegate(string value, string unit, IFormatProvider formatProvider2)
                 {
                     double parsedValue = double.Parse(value, formatProvider2);
                     InformationUnit parsedUnit = ParseUnit(unit, formatProvider2);
                     return From(parsedValue, parsedUnit);
-                }, (x, y) => FromBits(x.Bits + y.Bits), typeof(InformationUnit));
+                }, (x, y) => FromBits(x.Bits + y.Bits));
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/UnitClasses/KinematicViscosity.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/KinematicViscosity.g.cs
@@ -672,13 +672,13 @@ namespace UnitsNet
 #else
             IFormatProvider formatProvider = culture;
 #endif
-            return UnitParser.ParseUnit<KinematicViscosity>(str, formatProvider,
+            return UnitParser.ParseUnit<KinematicViscosityUnit, KinematicViscosity>(str, formatProvider,
                 delegate(string value, string unit, IFormatProvider formatProvider2)
                 {
                     double parsedValue = double.Parse(value, formatProvider2);
                     KinematicViscosityUnit parsedUnit = ParseUnit(unit, formatProvider2);
                     return From(parsedValue, parsedUnit);
-                }, (x, y) => FromSquareMetersPerSecond(x.SquareMetersPerSecond + y.SquareMetersPerSecond), typeof(KinematicViscosityUnit));
+                }, (x, y) => FromSquareMetersPerSecond(x.SquareMetersPerSecond + y.SquareMetersPerSecond));
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/UnitClasses/KinematicViscosity.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/KinematicViscosity.g.cs
@@ -678,7 +678,7 @@ namespace UnitsNet
                     double parsedValue = double.Parse(value, formatProvider2);
                     KinematicViscosityUnit parsedUnit = ParseUnit(unit, formatProvider2);
                     return From(parsedValue, parsedUnit);
-                }, (x, y) => FromSquareMetersPerSecond(x.SquareMetersPerSecond + y.SquareMetersPerSecond));
+                }, (x, y) => FromSquareMetersPerSecond(x.SquareMetersPerSecond + y.SquareMetersPerSecond), typeof(KinematicViscosityUnit));
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/UnitClasses/Length.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/Length.g.cs
@@ -1011,7 +1011,7 @@ namespace UnitsNet
                     double parsedValue = double.Parse(value, formatProvider2);
                     LengthUnit parsedUnit = ParseUnit(unit, formatProvider2);
                     return From(parsedValue, parsedUnit);
-                }, (x, y) => FromMeters(x.Meters + y.Meters));
+                }, (x, y) => FromMeters(x.Meters + y.Meters), typeof(LengthUnit));
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/UnitClasses/Length.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/Length.g.cs
@@ -1005,13 +1005,13 @@ namespace UnitsNet
 #else
             IFormatProvider formatProvider = culture;
 #endif
-            return UnitParser.ParseUnit<Length>(str, formatProvider,
+            return UnitParser.ParseUnit<LengthUnit, Length>(str, formatProvider,
                 delegate(string value, string unit, IFormatProvider formatProvider2)
                 {
                     double parsedValue = double.Parse(value, formatProvider2);
                     LengthUnit parsedUnit = ParseUnit(unit, formatProvider2);
                     return From(parsedValue, parsedUnit);
-                }, (x, y) => FromMeters(x.Meters + y.Meters), typeof(LengthUnit));
+                }, (x, y) => FromMeters(x.Meters + y.Meters));
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/UnitClasses/Level.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/Level.g.cs
@@ -464,7 +464,7 @@ namespace UnitsNet
                     double parsedValue = double.Parse(value, formatProvider2);
                     LevelUnit parsedUnit = ParseUnit(unit, formatProvider2);
                     return From(parsedValue, parsedUnit);
-                }, (x, y) => FromDecibels(x.Decibels + y.Decibels));
+                }, (x, y) => FromDecibels(x.Decibels + y.Decibels), typeof(LevelUnit));
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/UnitClasses/Level.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/Level.g.cs
@@ -458,13 +458,13 @@ namespace UnitsNet
 #else
             IFormatProvider formatProvider = culture;
 #endif
-            return UnitParser.ParseUnit<Level>(str, formatProvider,
+            return UnitParser.ParseUnit<LevelUnit, Level>(str, formatProvider,
                 delegate(string value, string unit, IFormatProvider formatProvider2)
                 {
                     double parsedValue = double.Parse(value, formatProvider2);
                     LevelUnit parsedUnit = ParseUnit(unit, formatProvider2);
                     return From(parsedValue, parsedUnit);
-                }, (x, y) => FromDecibels(x.Decibels + y.Decibels), typeof(LevelUnit));
+                }, (x, y) => FromDecibels(x.Decibels + y.Decibels));
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/UnitClasses/Mass.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/Mass.g.cs
@@ -1085,7 +1085,7 @@ namespace UnitsNet
                     double parsedValue = double.Parse(value, formatProvider2);
                     MassUnit parsedUnit = ParseUnit(unit, formatProvider2);
                     return From(parsedValue, parsedUnit);
-                }, (x, y) => FromKilograms(x.Kilograms + y.Kilograms));
+                }, (x, y) => FromKilograms(x.Kilograms + y.Kilograms), typeof(MassUnit));
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/UnitClasses/Mass.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/Mass.g.cs
@@ -1079,13 +1079,13 @@ namespace UnitsNet
 #else
             IFormatProvider formatProvider = culture;
 #endif
-            return UnitParser.ParseUnit<Mass>(str, formatProvider,
+            return UnitParser.ParseUnit<MassUnit, Mass>(str, formatProvider,
                 delegate(string value, string unit, IFormatProvider formatProvider2)
                 {
                     double parsedValue = double.Parse(value, formatProvider2);
                     MassUnit parsedUnit = ParseUnit(unit, formatProvider2);
                     return From(parsedValue, parsedUnit);
-                }, (x, y) => FromKilograms(x.Kilograms + y.Kilograms), typeof(MassUnit));
+                }, (x, y) => FromKilograms(x.Kilograms + y.Kilograms));
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/UnitClasses/MassFlow.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/MassFlow.g.cs
@@ -826,7 +826,7 @@ namespace UnitsNet
                     double parsedValue = double.Parse(value, formatProvider2);
                     MassFlowUnit parsedUnit = ParseUnit(unit, formatProvider2);
                     return From(parsedValue, parsedUnit);
-                }, (x, y) => FromGramsPerSecond(x.GramsPerSecond + y.GramsPerSecond));
+                }, (x, y) => FromGramsPerSecond(x.GramsPerSecond + y.GramsPerSecond), typeof(MassFlowUnit));
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/UnitClasses/MassFlow.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/MassFlow.g.cs
@@ -820,13 +820,13 @@ namespace UnitsNet
 #else
             IFormatProvider formatProvider = culture;
 #endif
-            return UnitParser.ParseUnit<MassFlow>(str, formatProvider,
+            return UnitParser.ParseUnit<MassFlowUnit, MassFlow>(str, formatProvider,
                 delegate(string value, string unit, IFormatProvider formatProvider2)
                 {
                     double parsedValue = double.Parse(value, formatProvider2);
                     MassFlowUnit parsedUnit = ParseUnit(unit, formatProvider2);
                     return From(parsedValue, parsedUnit);
-                }, (x, y) => FromGramsPerSecond(x.GramsPerSecond + y.GramsPerSecond), typeof(MassFlowUnit));
+                }, (x, y) => FromGramsPerSecond(x.GramsPerSecond + y.GramsPerSecond));
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/UnitClasses/Molarity.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/Molarity.g.cs
@@ -678,7 +678,7 @@ namespace UnitsNet
                     double parsedValue = double.Parse(value, formatProvider2);
                     MolarityUnit parsedUnit = ParseUnit(unit, formatProvider2);
                     return From(parsedValue, parsedUnit);
-                }, (x, y) => FromMolesPerCubicMeter(x.MolesPerCubicMeter + y.MolesPerCubicMeter));
+                }, (x, y) => FromMolesPerCubicMeter(x.MolesPerCubicMeter + y.MolesPerCubicMeter), typeof(MolarityUnit));
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/UnitClasses/Molarity.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/Molarity.g.cs
@@ -672,13 +672,13 @@ namespace UnitsNet
 #else
             IFormatProvider formatProvider = culture;
 #endif
-            return UnitParser.ParseUnit<Molarity>(str, formatProvider,
+            return UnitParser.ParseUnit<MolarityUnit, Molarity>(str, formatProvider,
                 delegate(string value, string unit, IFormatProvider formatProvider2)
                 {
                     double parsedValue = double.Parse(value, formatProvider2);
                     MolarityUnit parsedUnit = ParseUnit(unit, formatProvider2);
                     return From(parsedValue, parsedUnit);
-                }, (x, y) => FromMolesPerCubicMeter(x.MolesPerCubicMeter + y.MolesPerCubicMeter), typeof(MolarityUnit));
+                }, (x, y) => FromMolesPerCubicMeter(x.MolesPerCubicMeter + y.MolesPerCubicMeter));
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/UnitClasses/Power.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/Power.g.cs
@@ -968,13 +968,13 @@ namespace UnitsNet
 #else
             IFormatProvider formatProvider = culture;
 #endif
-            return UnitParser.ParseUnit<Power>(str, formatProvider,
+            return UnitParser.ParseUnit<PowerUnit, Power>(str, formatProvider,
                 delegate(string value, string unit, IFormatProvider formatProvider2)
                 {
                     double parsedValue = double.Parse(value, formatProvider2);
                     PowerUnit parsedUnit = ParseUnit(unit, formatProvider2);
                     return From(parsedValue, parsedUnit);
-                }, (x, y) => FromWatts(x.Watts + y.Watts), typeof(PowerUnit));
+                }, (x, y) => FromWatts(x.Watts + y.Watts));
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/UnitClasses/Power.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/Power.g.cs
@@ -974,7 +974,7 @@ namespace UnitsNet
                     double parsedValue = double.Parse(value, formatProvider2);
                     PowerUnit parsedUnit = ParseUnit(unit, formatProvider2);
                     return From(parsedValue, parsedUnit);
-                }, (x, y) => FromWatts(x.Watts + y.Watts));
+                }, (x, y) => FromWatts(x.Watts + y.Watts), typeof(PowerUnit));
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/UnitClasses/PowerRatio.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/PowerRatio.g.cs
@@ -464,7 +464,7 @@ namespace UnitsNet
                     double parsedValue = double.Parse(value, formatProvider2);
                     PowerRatioUnit parsedUnit = ParseUnit(unit, formatProvider2);
                     return From(parsedValue, parsedUnit);
-                }, (x, y) => FromDecibelWatts(x.DecibelWatts + y.DecibelWatts));
+                }, (x, y) => FromDecibelWatts(x.DecibelWatts + y.DecibelWatts), typeof(PowerRatioUnit));
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/UnitClasses/PowerRatio.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/PowerRatio.g.cs
@@ -458,13 +458,13 @@ namespace UnitsNet
 #else
             IFormatProvider formatProvider = culture;
 #endif
-            return UnitParser.ParseUnit<PowerRatio>(str, formatProvider,
+            return UnitParser.ParseUnit<PowerRatioUnit, PowerRatio>(str, formatProvider,
                 delegate(string value, string unit, IFormatProvider formatProvider2)
                 {
                     double parsedValue = double.Parse(value, formatProvider2);
                     PowerRatioUnit parsedUnit = ParseUnit(unit, formatProvider2);
                     return From(parsedValue, parsedUnit);
-                }, (x, y) => FromDecibelWatts(x.DecibelWatts + y.DecibelWatts), typeof(PowerRatioUnit));
+                }, (x, y) => FromDecibelWatts(x.DecibelWatts + y.DecibelWatts));
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/UnitClasses/Pressure.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/Pressure.g.cs
@@ -1746,13 +1746,13 @@ namespace UnitsNet
 #else
             IFormatProvider formatProvider = culture;
 #endif
-            return UnitParser.ParseUnit<Pressure>(str, formatProvider,
+            return UnitParser.ParseUnit<PressureUnit, Pressure>(str, formatProvider,
                 delegate(string value, string unit, IFormatProvider formatProvider2)
                 {
                     double parsedValue = double.Parse(value, formatProvider2);
                     PressureUnit parsedUnit = ParseUnit(unit, formatProvider2);
                     return From(parsedValue, parsedUnit);
-                }, (x, y) => FromPascals(x.Pascals + y.Pascals), typeof(PressureUnit));
+                }, (x, y) => FromPascals(x.Pascals + y.Pascals));
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/UnitClasses/Pressure.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/Pressure.g.cs
@@ -1752,7 +1752,7 @@ namespace UnitsNet
                     double parsedValue = double.Parse(value, formatProvider2);
                     PressureUnit parsedUnit = ParseUnit(unit, formatProvider2);
                     return From(parsedValue, parsedUnit);
-                }, (x, y) => FromPascals(x.Pascals + y.Pascals));
+                }, (x, y) => FromPascals(x.Pascals + y.Pascals), typeof(PressureUnit));
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/UnitClasses/PressureChangeRate.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/PressureChangeRate.g.cs
@@ -530,7 +530,7 @@ namespace UnitsNet
                     double parsedValue = double.Parse(value, formatProvider2);
                     PressureChangeRateUnit parsedUnit = ParseUnit(unit, formatProvider2);
                     return From(parsedValue, parsedUnit);
-                }, (x, y) => FromPascalsPerSecond(x.PascalsPerSecond + y.PascalsPerSecond));
+                }, (x, y) => FromPascalsPerSecond(x.PascalsPerSecond + y.PascalsPerSecond), typeof(PressureChangeRateUnit));
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/UnitClasses/PressureChangeRate.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/PressureChangeRate.g.cs
@@ -524,13 +524,13 @@ namespace UnitsNet
 #else
             IFormatProvider formatProvider = culture;
 #endif
-            return UnitParser.ParseUnit<PressureChangeRate>(str, formatProvider,
+            return UnitParser.ParseUnit<PressureChangeRateUnit, PressureChangeRate>(str, formatProvider,
                 delegate(string value, string unit, IFormatProvider formatProvider2)
                 {
                     double parsedValue = double.Parse(value, formatProvider2);
                     PressureChangeRateUnit parsedUnit = ParseUnit(unit, formatProvider2);
                     return From(parsedValue, parsedUnit);
-                }, (x, y) => FromPascalsPerSecond(x.PascalsPerSecond + y.PascalsPerSecond), typeof(PressureChangeRateUnit));
+                }, (x, y) => FromPascalsPerSecond(x.PascalsPerSecond + y.PascalsPerSecond));
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/UnitClasses/Ratio.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/Ratio.g.cs
@@ -604,7 +604,7 @@ namespace UnitsNet
                     double parsedValue = double.Parse(value, formatProvider2);
                     RatioUnit parsedUnit = ParseUnit(unit, formatProvider2);
                     return From(parsedValue, parsedUnit);
-                }, (x, y) => FromDecimalFractions(x.DecimalFractions + y.DecimalFractions));
+                }, (x, y) => FromDecimalFractions(x.DecimalFractions + y.DecimalFractions), typeof(RatioUnit));
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/UnitClasses/Ratio.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/Ratio.g.cs
@@ -598,13 +598,13 @@ namespace UnitsNet
 #else
             IFormatProvider formatProvider = culture;
 #endif
-            return UnitParser.ParseUnit<Ratio>(str, formatProvider,
+            return UnitParser.ParseUnit<RatioUnit, Ratio>(str, formatProvider,
                 delegate(string value, string unit, IFormatProvider formatProvider2)
                 {
                     double parsedValue = double.Parse(value, formatProvider2);
                     RatioUnit parsedUnit = ParseUnit(unit, formatProvider2);
                     return From(parsedValue, parsedUnit);
-                }, (x, y) => FromDecimalFractions(x.DecimalFractions + y.DecimalFractions), typeof(RatioUnit));
+                }, (x, y) => FromDecimalFractions(x.DecimalFractions + y.DecimalFractions));
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/UnitClasses/ReactivePower.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/ReactivePower.g.cs
@@ -487,13 +487,13 @@ namespace UnitsNet
 #else
             IFormatProvider formatProvider = culture;
 #endif
-            return UnitParser.ParseUnit<ReactivePower>(str, formatProvider,
+            return UnitParser.ParseUnit<ReactivePowerUnit, ReactivePower>(str, formatProvider,
                 delegate(string value, string unit, IFormatProvider formatProvider2)
                 {
                     double parsedValue = double.Parse(value, formatProvider2);
                     ReactivePowerUnit parsedUnit = ParseUnit(unit, formatProvider2);
                     return From(parsedValue, parsedUnit);
-                }, (x, y) => FromVoltamperesReactive(x.VoltamperesReactive + y.VoltamperesReactive), typeof(ReactivePowerUnit));
+                }, (x, y) => FromVoltamperesReactive(x.VoltamperesReactive + y.VoltamperesReactive));
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/UnitClasses/ReactivePower.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/ReactivePower.g.cs
@@ -493,7 +493,7 @@ namespace UnitsNet
                     double parsedValue = double.Parse(value, formatProvider2);
                     ReactivePowerUnit parsedUnit = ParseUnit(unit, formatProvider2);
                     return From(parsedValue, parsedUnit);
-                }, (x, y) => FromVoltamperesReactive(x.VoltamperesReactive + y.VoltamperesReactive));
+                }, (x, y) => FromVoltamperesReactive(x.VoltamperesReactive + y.VoltamperesReactive), typeof(ReactivePowerUnit));
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/UnitClasses/RotationalAcceleration.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/RotationalAcceleration.g.cs
@@ -450,13 +450,13 @@ namespace UnitsNet
 #else
             IFormatProvider formatProvider = culture;
 #endif
-            return UnitParser.ParseUnit<RotationalAcceleration>(str, formatProvider,
+            return UnitParser.ParseUnit<RotationalAccelerationUnit, RotationalAcceleration>(str, formatProvider,
                 delegate(string value, string unit, IFormatProvider formatProvider2)
                 {
                     double parsedValue = double.Parse(value, formatProvider2);
                     RotationalAccelerationUnit parsedUnit = ParseUnit(unit, formatProvider2);
                     return From(parsedValue, parsedUnit);
-                }, (x, y) => FromRadiansPerSecondSquared(x.RadiansPerSecondSquared + y.RadiansPerSecondSquared), typeof(RotationalAccelerationUnit));
+                }, (x, y) => FromRadiansPerSecondSquared(x.RadiansPerSecondSquared + y.RadiansPerSecondSquared));
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/UnitClasses/RotationalAcceleration.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/RotationalAcceleration.g.cs
@@ -456,7 +456,7 @@ namespace UnitsNet
                     double parsedValue = double.Parse(value, formatProvider2);
                     RotationalAccelerationUnit parsedUnit = ParseUnit(unit, formatProvider2);
                     return From(parsedValue, parsedUnit);
-                }, (x, y) => FromRadiansPerSecondSquared(x.RadiansPerSecondSquared + y.RadiansPerSecondSquared));
+                }, (x, y) => FromRadiansPerSecondSquared(x.RadiansPerSecondSquared + y.RadiansPerSecondSquared), typeof(RotationalAccelerationUnit));
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/UnitClasses/RotationalSpeed.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/RotationalSpeed.g.cs
@@ -863,7 +863,7 @@ namespace UnitsNet
                     double parsedValue = double.Parse(value, formatProvider2);
                     RotationalSpeedUnit parsedUnit = ParseUnit(unit, formatProvider2);
                     return From(parsedValue, parsedUnit);
-                }, (x, y) => FromRadiansPerSecond(x.RadiansPerSecond + y.RadiansPerSecond));
+                }, (x, y) => FromRadiansPerSecond(x.RadiansPerSecond + y.RadiansPerSecond), typeof(RotationalSpeedUnit));
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/UnitClasses/RotationalSpeed.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/RotationalSpeed.g.cs
@@ -857,13 +857,13 @@ namespace UnitsNet
 #else
             IFormatProvider formatProvider = culture;
 #endif
-            return UnitParser.ParseUnit<RotationalSpeed>(str, formatProvider,
+            return UnitParser.ParseUnit<RotationalSpeedUnit, RotationalSpeed>(str, formatProvider,
                 delegate(string value, string unit, IFormatProvider formatProvider2)
                 {
                     double parsedValue = double.Parse(value, formatProvider2);
                     RotationalSpeedUnit parsedUnit = ParseUnit(unit, formatProvider2);
                     return From(parsedValue, parsedUnit);
-                }, (x, y) => FromRadiansPerSecond(x.RadiansPerSecond + y.RadiansPerSecond), typeof(RotationalSpeedUnit));
+                }, (x, y) => FromRadiansPerSecond(x.RadiansPerSecond + y.RadiansPerSecond));
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/UnitClasses/SpecificEnergy.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/SpecificEnergy.g.cs
@@ -678,7 +678,7 @@ namespace UnitsNet
                     double parsedValue = double.Parse(value, formatProvider2);
                     SpecificEnergyUnit parsedUnit = ParseUnit(unit, formatProvider2);
                     return From(parsedValue, parsedUnit);
-                }, (x, y) => FromJoulesPerKilogram(x.JoulesPerKilogram + y.JoulesPerKilogram));
+                }, (x, y) => FromJoulesPerKilogram(x.JoulesPerKilogram + y.JoulesPerKilogram), typeof(SpecificEnergyUnit));
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/UnitClasses/SpecificEnergy.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/SpecificEnergy.g.cs
@@ -672,13 +672,13 @@ namespace UnitsNet
 #else
             IFormatProvider formatProvider = culture;
 #endif
-            return UnitParser.ParseUnit<SpecificEnergy>(str, formatProvider,
+            return UnitParser.ParseUnit<SpecificEnergyUnit, SpecificEnergy>(str, formatProvider,
                 delegate(string value, string unit, IFormatProvider formatProvider2)
                 {
                     double parsedValue = double.Parse(value, formatProvider2);
                     SpecificEnergyUnit parsedUnit = ParseUnit(unit, formatProvider2);
                     return From(parsedValue, parsedUnit);
-                }, (x, y) => FromJoulesPerKilogram(x.JoulesPerKilogram + y.JoulesPerKilogram), typeof(SpecificEnergyUnit));
+                }, (x, y) => FromJoulesPerKilogram(x.JoulesPerKilogram + y.JoulesPerKilogram));
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/UnitClasses/SpecificWeight.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/SpecificWeight.g.cs
@@ -974,7 +974,7 @@ namespace UnitsNet
                     double parsedValue = double.Parse(value, formatProvider2);
                     SpecificWeightUnit parsedUnit = ParseUnit(unit, formatProvider2);
                     return From(parsedValue, parsedUnit);
-                }, (x, y) => FromNewtonsPerCubicMeter(x.NewtonsPerCubicMeter + y.NewtonsPerCubicMeter));
+                }, (x, y) => FromNewtonsPerCubicMeter(x.NewtonsPerCubicMeter + y.NewtonsPerCubicMeter), typeof(SpecificWeightUnit));
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/UnitClasses/SpecificWeight.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/SpecificWeight.g.cs
@@ -968,13 +968,13 @@ namespace UnitsNet
 #else
             IFormatProvider formatProvider = culture;
 #endif
-            return UnitParser.ParseUnit<SpecificWeight>(str, formatProvider,
+            return UnitParser.ParseUnit<SpecificWeightUnit, SpecificWeight>(str, formatProvider,
                 delegate(string value, string unit, IFormatProvider formatProvider2)
                 {
                     double parsedValue = double.Parse(value, formatProvider2);
                     SpecificWeightUnit parsedUnit = ParseUnit(unit, formatProvider2);
                     return From(parsedValue, parsedUnit);
-                }, (x, y) => FromNewtonsPerCubicMeter(x.NewtonsPerCubicMeter + y.NewtonsPerCubicMeter), typeof(SpecificWeightUnit));
+                }, (x, y) => FromNewtonsPerCubicMeter(x.NewtonsPerCubicMeter + y.NewtonsPerCubicMeter));
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/UnitClasses/Speed.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/Speed.g.cs
@@ -1153,13 +1153,13 @@ namespace UnitsNet
 #else
             IFormatProvider formatProvider = culture;
 #endif
-            return UnitParser.ParseUnit<Speed>(str, formatProvider,
+            return UnitParser.ParseUnit<SpeedUnit, Speed>(str, formatProvider,
                 delegate(string value, string unit, IFormatProvider formatProvider2)
                 {
                     double parsedValue = double.Parse(value, formatProvider2);
                     SpeedUnit parsedUnit = ParseUnit(unit, formatProvider2);
                     return From(parsedValue, parsedUnit);
-                }, (x, y) => FromMetersPerSecond(x.MetersPerSecond + y.MetersPerSecond), typeof(SpeedUnit));
+                }, (x, y) => FromMetersPerSecond(x.MetersPerSecond + y.MetersPerSecond));
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/UnitClasses/Speed.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/Speed.g.cs
@@ -1159,7 +1159,7 @@ namespace UnitsNet
                     double parsedValue = double.Parse(value, formatProvider2);
                     SpeedUnit parsedUnit = ParseUnit(unit, formatProvider2);
                     return From(parsedValue, parsedUnit);
-                }, (x, y) => FromMetersPerSecond(x.MetersPerSecond + y.MetersPerSecond));
+                }, (x, y) => FromMetersPerSecond(x.MetersPerSecond + y.MetersPerSecond), typeof(SpeedUnit));
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/UnitClasses/Temperature.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/Temperature.g.cs
@@ -637,7 +637,7 @@ namespace UnitsNet
                     double parsedValue = double.Parse(value, formatProvider2);
                     TemperatureUnit parsedUnit = ParseUnit(unit, formatProvider2);
                     return From(parsedValue, parsedUnit);
-                }, (x, y) => FromKelvins(x.Kelvins + y.Kelvins));
+                }, (x, y) => FromKelvins(x.Kelvins + y.Kelvins), typeof(TemperatureUnit));
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/UnitClasses/Temperature.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/Temperature.g.cs
@@ -631,13 +631,13 @@ namespace UnitsNet
 #else
             IFormatProvider formatProvider = culture;
 #endif
-            return UnitParser.ParseUnit<Temperature>(str, formatProvider,
+            return UnitParser.ParseUnit<TemperatureUnit, Temperature>(str, formatProvider,
                 delegate(string value, string unit, IFormatProvider formatProvider2)
                 {
                     double parsedValue = double.Parse(value, formatProvider2);
                     TemperatureUnit parsedUnit = ParseUnit(unit, formatProvider2);
                     return From(parsedValue, parsedUnit);
-                }, (x, y) => FromKelvins(x.Kelvins + y.Kelvins), typeof(TemperatureUnit));
+                }, (x, y) => FromKelvins(x.Kelvins + y.Kelvins));
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/UnitClasses/TemperatureChangeRate.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/TemperatureChangeRate.g.cs
@@ -709,13 +709,13 @@ namespace UnitsNet
 #else
             IFormatProvider formatProvider = culture;
 #endif
-            return UnitParser.ParseUnit<TemperatureChangeRate>(str, formatProvider,
+            return UnitParser.ParseUnit<TemperatureChangeRateUnit, TemperatureChangeRate>(str, formatProvider,
                 delegate(string value, string unit, IFormatProvider formatProvider2)
                 {
                     double parsedValue = double.Parse(value, formatProvider2);
                     TemperatureChangeRateUnit parsedUnit = ParseUnit(unit, formatProvider2);
                     return From(parsedValue, parsedUnit);
-                }, (x, y) => FromDegreesCelsiusPerSecond(x.DegreesCelsiusPerSecond + y.DegreesCelsiusPerSecond), typeof(TemperatureChangeRateUnit));
+                }, (x, y) => FromDegreesCelsiusPerSecond(x.DegreesCelsiusPerSecond + y.DegreesCelsiusPerSecond));
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/UnitClasses/TemperatureChangeRate.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/TemperatureChangeRate.g.cs
@@ -715,7 +715,7 @@ namespace UnitsNet
                     double parsedValue = double.Parse(value, formatProvider2);
                     TemperatureChangeRateUnit parsedUnit = ParseUnit(unit, formatProvider2);
                     return From(parsedValue, parsedUnit);
-                }, (x, y) => FromDegreesCelsiusPerSecond(x.DegreesCelsiusPerSecond + y.DegreesCelsiusPerSecond));
+                }, (x, y) => FromDegreesCelsiusPerSecond(x.DegreesCelsiusPerSecond + y.DegreesCelsiusPerSecond), typeof(TemperatureChangeRateUnit));
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/UnitClasses/TemperatureDelta.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/TemperatureDelta.g.cs
@@ -678,7 +678,7 @@ namespace UnitsNet
                     double parsedValue = double.Parse(value, formatProvider2);
                     TemperatureDeltaUnit parsedUnit = ParseUnit(unit, formatProvider2);
                     return From(parsedValue, parsedUnit);
-                }, (x, y) => FromKelvinsDelta(x.KelvinsDelta + y.KelvinsDelta));
+                }, (x, y) => FromKelvinsDelta(x.KelvinsDelta + y.KelvinsDelta), typeof(TemperatureDeltaUnit));
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/UnitClasses/TemperatureDelta.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/TemperatureDelta.g.cs
@@ -672,13 +672,13 @@ namespace UnitsNet
 #else
             IFormatProvider formatProvider = culture;
 #endif
-            return UnitParser.ParseUnit<TemperatureDelta>(str, formatProvider,
+            return UnitParser.ParseUnit<TemperatureDeltaUnit, TemperatureDelta>(str, formatProvider,
                 delegate(string value, string unit, IFormatProvider formatProvider2)
                 {
                     double parsedValue = double.Parse(value, formatProvider2);
                     TemperatureDeltaUnit parsedUnit = ParseUnit(unit, formatProvider2);
                     return From(parsedValue, parsedUnit);
-                }, (x, y) => FromKelvinsDelta(x.KelvinsDelta + y.KelvinsDelta), typeof(TemperatureDeltaUnit));
+                }, (x, y) => FromKelvinsDelta(x.KelvinsDelta + y.KelvinsDelta));
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/UnitClasses/ThermalResistance.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/ThermalResistance.g.cs
@@ -561,13 +561,13 @@ namespace UnitsNet
 #else
             IFormatProvider formatProvider = culture;
 #endif
-            return UnitParser.ParseUnit<ThermalResistance>(str, formatProvider,
+            return UnitParser.ParseUnit<ThermalResistanceUnit, ThermalResistance>(str, formatProvider,
                 delegate(string value, string unit, IFormatProvider formatProvider2)
                 {
                     double parsedValue = double.Parse(value, formatProvider2);
                     ThermalResistanceUnit parsedUnit = ParseUnit(unit, formatProvider2);
                     return From(parsedValue, parsedUnit);
-                }, (x, y) => FromSquareMeterKelvinsPerKilowatt(x.SquareMeterKelvinsPerKilowatt + y.SquareMeterKelvinsPerKilowatt), typeof(ThermalResistanceUnit));
+                }, (x, y) => FromSquareMeterKelvinsPerKilowatt(x.SquareMeterKelvinsPerKilowatt + y.SquareMeterKelvinsPerKilowatt));
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/UnitClasses/ThermalResistance.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/ThermalResistance.g.cs
@@ -567,7 +567,7 @@ namespace UnitsNet
                     double parsedValue = double.Parse(value, formatProvider2);
                     ThermalResistanceUnit parsedUnit = ParseUnit(unit, formatProvider2);
                     return From(parsedValue, parsedUnit);
-                }, (x, y) => FromSquareMeterKelvinsPerKilowatt(x.SquareMeterKelvinsPerKilowatt + y.SquareMeterKelvinsPerKilowatt));
+                }, (x, y) => FromSquareMeterKelvinsPerKilowatt(x.SquareMeterKelvinsPerKilowatt + y.SquareMeterKelvinsPerKilowatt), typeof(ThermalResistanceUnit));
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/UnitClasses/Torque.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/Torque.g.cs
@@ -968,13 +968,13 @@ namespace UnitsNet
 #else
             IFormatProvider formatProvider = culture;
 #endif
-            return UnitParser.ParseUnit<Torque>(str, formatProvider,
+            return UnitParser.ParseUnit<TorqueUnit, Torque>(str, formatProvider,
                 delegate(string value, string unit, IFormatProvider formatProvider2)
                 {
                     double parsedValue = double.Parse(value, formatProvider2);
                     TorqueUnit parsedUnit = ParseUnit(unit, formatProvider2);
                     return From(parsedValue, parsedUnit);
-                }, (x, y) => FromNewtonMeters(x.NewtonMeters + y.NewtonMeters), typeof(TorqueUnit));
+                }, (x, y) => FromNewtonMeters(x.NewtonMeters + y.NewtonMeters));
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/UnitClasses/Torque.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/Torque.g.cs
@@ -974,7 +974,7 @@ namespace UnitsNet
                     double parsedValue = double.Parse(value, formatProvider2);
                     TorqueUnit parsedUnit = ParseUnit(unit, formatProvider2);
                     return From(parsedValue, parsedUnit);
-                }, (x, y) => FromNewtonMeters(x.NewtonMeters + y.NewtonMeters));
+                }, (x, y) => FromNewtonMeters(x.NewtonMeters + y.NewtonMeters), typeof(TorqueUnit));
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/UnitClasses/VitaminA.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/VitaminA.g.cs
@@ -413,13 +413,13 @@ namespace UnitsNet
 #else
             IFormatProvider formatProvider = culture;
 #endif
-            return UnitParser.ParseUnit<VitaminA>(str, formatProvider,
+            return UnitParser.ParseUnit<VitaminAUnit, VitaminA>(str, formatProvider,
                 delegate(string value, string unit, IFormatProvider formatProvider2)
                 {
                     double parsedValue = double.Parse(value, formatProvider2);
                     VitaminAUnit parsedUnit = ParseUnit(unit, formatProvider2);
                     return From(parsedValue, parsedUnit);
-                }, (x, y) => FromInternationalUnits(x.InternationalUnits + y.InternationalUnits), typeof(VitaminAUnit));
+                }, (x, y) => FromInternationalUnits(x.InternationalUnits + y.InternationalUnits));
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/UnitClasses/VitaminA.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/VitaminA.g.cs
@@ -419,7 +419,7 @@ namespace UnitsNet
                     double parsedValue = double.Parse(value, formatProvider2);
                     VitaminAUnit parsedUnit = ParseUnit(unit, formatProvider2);
                     return From(parsedValue, parsedUnit);
-                }, (x, y) => FromInternationalUnits(x.InternationalUnits + y.InternationalUnits));
+                }, (x, y) => FromInternationalUnits(x.InternationalUnits + y.InternationalUnits), typeof(VitaminAUnit));
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/UnitClasses/Volume.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/Volume.g.cs
@@ -1531,7 +1531,7 @@ namespace UnitsNet
                     double parsedValue = double.Parse(value, formatProvider2);
                     VolumeUnit parsedUnit = ParseUnit(unit, formatProvider2);
                     return From(parsedValue, parsedUnit);
-                }, (x, y) => FromCubicMeters(x.CubicMeters + y.CubicMeters));
+                }, (x, y) => FromCubicMeters(x.CubicMeters + y.CubicMeters), typeof(VolumeUnit));
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/UnitClasses/Volume.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/Volume.g.cs
@@ -1525,13 +1525,13 @@ namespace UnitsNet
 #else
             IFormatProvider formatProvider = culture;
 #endif
-            return UnitParser.ParseUnit<Volume>(str, formatProvider,
+            return UnitParser.ParseUnit<VolumeUnit, Volume>(str, formatProvider,
                 delegate(string value, string unit, IFormatProvider formatProvider2)
                 {
                     double parsedValue = double.Parse(value, formatProvider2);
                     VolumeUnit parsedUnit = ParseUnit(unit, formatProvider2);
                     return From(parsedValue, parsedUnit);
-                }, (x, y) => FromCubicMeters(x.CubicMeters + y.CubicMeters), typeof(VolumeUnit));
+                }, (x, y) => FromCubicMeters(x.CubicMeters + y.CubicMeters));
         }
 
         /// <summary>

--- a/UnitsNet/Scripts/Include-GenerateUnitClassSourceCode.ps1
+++ b/UnitsNet/Scripts/Include-GenerateUnitClassSourceCode.ps1
@@ -479,7 +479,7 @@ namespace UnitsNet
                     double parsedValue = double.Parse(value, formatProvider2);
                     $unitEnumName parsedUnit = ParseUnit(unit, formatProvider2);
                     return From(parsedValue, parsedUnit);
-                }, (x, y) => From$baseUnitPluralName(x.$baseUnitPluralName + y.$baseUnitPluralName));
+                }, (x, y) => From$baseUnitPluralName(x.$baseUnitPluralName + y.$baseUnitPluralName), typeof($unitEnumName));
         }
 
         /// <summary>

--- a/UnitsNet/Scripts/Include-GenerateUnitClassSourceCode.ps1
+++ b/UnitsNet/Scripts/Include-GenerateUnitClassSourceCode.ps1
@@ -473,13 +473,13 @@ namespace UnitsNet
 #else
             IFormatProvider formatProvider = culture;
 #endif
-            return UnitParser.ParseUnit<$className>(str, formatProvider,
+            return UnitParser.ParseUnit<$unitEnumName, $className>(str, formatProvider,
                 delegate(string value, string unit, IFormatProvider formatProvider2)
                 {
                     double parsedValue = double.Parse(value, formatProvider2);
                     $unitEnumName parsedUnit = ParseUnit(unit, formatProvider2);
                     return From(parsedValue, parsedUnit);
-                }, (x, y) => From$baseUnitPluralName(x.$baseUnitPluralName + y.$baseUnitPluralName), typeof($unitEnumName));
+                }, (x, y) => From$baseUnitPluralName(x.$baseUnitPluralName + y.$baseUnitPluralName));
         }
 
         /// <summary>


### PR DESCRIPTION
So the direction I went was to change the regex to in the UnitParser.ParseUnit to match one of any of the abbreviations for the unit type. This seems more robust as it uses UnitSystem abbreviations and allows for more flexible abbreviations (either mapped at run time or generated).

Related issue: #264 