### PR TITLE
Add US and UK Beer barrel volumes

### DIFF
--- a/UnitsNet.Tests/CustomCode/VolumeTests.cs
+++ b/UnitsNet.Tests/CustomCode/VolumeTests.cs
@@ -75,7 +75,11 @@ namespace UnitsNet.Tests.CustomCode
 
         protected override double TeaspoonsInOneCubicMeter => 202884.13621105801;
 
+        protected override double UkBeerBarrelsInOneCubicMeter => 6.1102568972;
+
         protected override double UkTablespoonsInOneCubicMeter => 66666.6666667;
+
+        protected override double UsBeerBarrelsInOneCubicMeter => 8.5216790723083;
 
         protected override double TeaspoonsTolerance => 1E-3;
 

--- a/UnitsNet.Tests/CustomCode/VolumeTests.cs
+++ b/UnitsNet.Tests/CustomCode/VolumeTests.cs
@@ -75,7 +75,7 @@ namespace UnitsNet.Tests.CustomCode
 
         protected override double TeaspoonsInOneCubicMeter => 202884.13621105801;
 
-        protected override double UkBeerBarrelsInOneCubicMeter => 6.1102568972;
+        protected override double ImperialBeerBarrelsInOneCubicMeter => 6.1102568972;
 
         protected override double UkTablespoonsInOneCubicMeter => 66666.6666667;
 

--- a/UnitsNet.Tests/GeneratedCode/VolumeTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/VolumeTestsBase.g.cs
@@ -76,7 +76,9 @@ namespace UnitsNet.Tests
         protected abstract double OilBarrelsInOneCubicMeter { get; }
         protected abstract double TablespoonsInOneCubicMeter { get; }
         protected abstract double TeaspoonsInOneCubicMeter { get; }
+        protected abstract double UkBeerBarrelsInOneCubicMeter { get; }
         protected abstract double UkTablespoonsInOneCubicMeter { get; }
+        protected abstract double UsBeerBarrelsInOneCubicMeter { get; }
         protected abstract double UsCustomaryCupsInOneCubicMeter { get; }
         protected abstract double UsGallonsInOneCubicMeter { get; }
         protected abstract double UsLegalCupsInOneCubicMeter { get; }
@@ -109,7 +111,9 @@ namespace UnitsNet.Tests
         protected virtual double OilBarrelsTolerance { get { return 1e-5; } }
         protected virtual double TablespoonsTolerance { get { return 1e-5; } }
         protected virtual double TeaspoonsTolerance { get { return 1e-5; } }
+        protected virtual double UkBeerBarrelsTolerance { get { return 1e-5; } }
         protected virtual double UkTablespoonsTolerance { get { return 1e-5; } }
+        protected virtual double UsBeerBarrelsTolerance { get { return 1e-5; } }
         protected virtual double UsCustomaryCupsTolerance { get { return 1e-5; } }
         protected virtual double UsGallonsTolerance { get { return 1e-5; } }
         protected virtual double UsLegalCupsTolerance { get { return 1e-5; } }
@@ -146,7 +150,9 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(OilBarrelsInOneCubicMeter, cubicmeter.OilBarrels, OilBarrelsTolerance);
             AssertEx.EqualTolerance(TablespoonsInOneCubicMeter, cubicmeter.Tablespoons, TablespoonsTolerance);
             AssertEx.EqualTolerance(TeaspoonsInOneCubicMeter, cubicmeter.Teaspoons, TeaspoonsTolerance);
+            AssertEx.EqualTolerance(UkBeerBarrelsInOneCubicMeter, cubicmeter.UkBeerBarrels, UkBeerBarrelsTolerance);
             AssertEx.EqualTolerance(UkTablespoonsInOneCubicMeter, cubicmeter.UkTablespoons, UkTablespoonsTolerance);
+            AssertEx.EqualTolerance(UsBeerBarrelsInOneCubicMeter, cubicmeter.UsBeerBarrels, UsBeerBarrelsTolerance);
             AssertEx.EqualTolerance(UsCustomaryCupsInOneCubicMeter, cubicmeter.UsCustomaryCups, UsCustomaryCupsTolerance);
             AssertEx.EqualTolerance(UsGallonsInOneCubicMeter, cubicmeter.UsGallons, UsGallonsTolerance);
             AssertEx.EqualTolerance(UsLegalCupsInOneCubicMeter, cubicmeter.UsLegalCups, UsLegalCupsTolerance);
@@ -182,7 +188,9 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, Volume.From(1, VolumeUnit.OilBarrel).OilBarrels, OilBarrelsTolerance);
             AssertEx.EqualTolerance(1, Volume.From(1, VolumeUnit.Tablespoon).Tablespoons, TablespoonsTolerance);
             AssertEx.EqualTolerance(1, Volume.From(1, VolumeUnit.Teaspoon).Teaspoons, TeaspoonsTolerance);
+            AssertEx.EqualTolerance(1, Volume.From(1, VolumeUnit.UkBeerBarrel).UkBeerBarrels, UkBeerBarrelsTolerance);
             AssertEx.EqualTolerance(1, Volume.From(1, VolumeUnit.UkTablespoon).UkTablespoons, UkTablespoonsTolerance);
+            AssertEx.EqualTolerance(1, Volume.From(1, VolumeUnit.UsBeerBarrel).UsBeerBarrels, UsBeerBarrelsTolerance);
             AssertEx.EqualTolerance(1, Volume.From(1, VolumeUnit.UsCustomaryCup).UsCustomaryCups, UsCustomaryCupsTolerance);
             AssertEx.EqualTolerance(1, Volume.From(1, VolumeUnit.UsGallon).UsGallons, UsGallonsTolerance);
             AssertEx.EqualTolerance(1, Volume.From(1, VolumeUnit.UsLegalCup).UsLegalCups, UsLegalCupsTolerance);
@@ -219,7 +227,9 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(OilBarrelsInOneCubicMeter, cubicmeter.As(VolumeUnit.OilBarrel), OilBarrelsTolerance);
             AssertEx.EqualTolerance(TablespoonsInOneCubicMeter, cubicmeter.As(VolumeUnit.Tablespoon), TablespoonsTolerance);
             AssertEx.EqualTolerance(TeaspoonsInOneCubicMeter, cubicmeter.As(VolumeUnit.Teaspoon), TeaspoonsTolerance);
+            AssertEx.EqualTolerance(UkBeerBarrelsInOneCubicMeter, cubicmeter.As(VolumeUnit.UkBeerBarrel), UkBeerBarrelsTolerance);
             AssertEx.EqualTolerance(UkTablespoonsInOneCubicMeter, cubicmeter.As(VolumeUnit.UkTablespoon), UkTablespoonsTolerance);
+            AssertEx.EqualTolerance(UsBeerBarrelsInOneCubicMeter, cubicmeter.As(VolumeUnit.UsBeerBarrel), UsBeerBarrelsTolerance);
             AssertEx.EqualTolerance(UsCustomaryCupsInOneCubicMeter, cubicmeter.As(VolumeUnit.UsCustomaryCup), UsCustomaryCupsTolerance);
             AssertEx.EqualTolerance(UsGallonsInOneCubicMeter, cubicmeter.As(VolumeUnit.UsGallon), UsGallonsTolerance);
             AssertEx.EqualTolerance(UsLegalCupsInOneCubicMeter, cubicmeter.As(VolumeUnit.UsLegalCup), UsLegalCupsTolerance);
@@ -256,7 +266,9 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, Volume.FromOilBarrels(cubicmeter.OilBarrels).CubicMeters, OilBarrelsTolerance);
             AssertEx.EqualTolerance(1, Volume.FromTablespoons(cubicmeter.Tablespoons).CubicMeters, TablespoonsTolerance);
             AssertEx.EqualTolerance(1, Volume.FromTeaspoons(cubicmeter.Teaspoons).CubicMeters, TeaspoonsTolerance);
+            AssertEx.EqualTolerance(1, Volume.FromUkBeerBarrels(cubicmeter.UkBeerBarrels).CubicMeters, UkBeerBarrelsTolerance);
             AssertEx.EqualTolerance(1, Volume.FromUkTablespoons(cubicmeter.UkTablespoons).CubicMeters, UkTablespoonsTolerance);
+            AssertEx.EqualTolerance(1, Volume.FromUsBeerBarrels(cubicmeter.UsBeerBarrels).CubicMeters, UsBeerBarrelsTolerance);
             AssertEx.EqualTolerance(1, Volume.FromUsCustomaryCups(cubicmeter.UsCustomaryCups).CubicMeters, UsCustomaryCupsTolerance);
             AssertEx.EqualTolerance(1, Volume.FromUsGallons(cubicmeter.UsGallons).CubicMeters, UsGallonsTolerance);
             AssertEx.EqualTolerance(1, Volume.FromUsLegalCups(cubicmeter.UsLegalCups).CubicMeters, UsLegalCupsTolerance);

--- a/UnitsNet.Tests/GeneratedCode/VolumeTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/VolumeTestsBase.g.cs
@@ -76,7 +76,7 @@ namespace UnitsNet.Tests
         protected abstract double OilBarrelsInOneCubicMeter { get; }
         protected abstract double TablespoonsInOneCubicMeter { get; }
         protected abstract double TeaspoonsInOneCubicMeter { get; }
-        protected abstract double UkBeerBarrelsInOneCubicMeter { get; }
+        protected abstract double ImperialBeerBarrelsInOneCubicMeter { get; }
         protected abstract double UkTablespoonsInOneCubicMeter { get; }
         protected abstract double UsBeerBarrelsInOneCubicMeter { get; }
         protected abstract double UsCustomaryCupsInOneCubicMeter { get; }
@@ -111,7 +111,7 @@ namespace UnitsNet.Tests
         protected virtual double OilBarrelsTolerance { get { return 1e-5; } }
         protected virtual double TablespoonsTolerance { get { return 1e-5; } }
         protected virtual double TeaspoonsTolerance { get { return 1e-5; } }
-        protected virtual double UkBeerBarrelsTolerance { get { return 1e-5; } }
+        protected virtual double ImperialBeerBarrelsTolerance { get { return 1e-5; } }
         protected virtual double UkTablespoonsTolerance { get { return 1e-5; } }
         protected virtual double UsBeerBarrelsTolerance { get { return 1e-5; } }
         protected virtual double UsCustomaryCupsTolerance { get { return 1e-5; } }
@@ -150,7 +150,7 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(OilBarrelsInOneCubicMeter, cubicmeter.OilBarrels, OilBarrelsTolerance);
             AssertEx.EqualTolerance(TablespoonsInOneCubicMeter, cubicmeter.Tablespoons, TablespoonsTolerance);
             AssertEx.EqualTolerance(TeaspoonsInOneCubicMeter, cubicmeter.Teaspoons, TeaspoonsTolerance);
-            AssertEx.EqualTolerance(UkBeerBarrelsInOneCubicMeter, cubicmeter.UkBeerBarrels, UkBeerBarrelsTolerance);
+            AssertEx.EqualTolerance(ImperialBeerBarrelsInOneCubicMeter, cubicmeter.ImperialBeerBarrels, ImperialBeerBarrelsTolerance);
             AssertEx.EqualTolerance(UkTablespoonsInOneCubicMeter, cubicmeter.UkTablespoons, UkTablespoonsTolerance);
             AssertEx.EqualTolerance(UsBeerBarrelsInOneCubicMeter, cubicmeter.UsBeerBarrels, UsBeerBarrelsTolerance);
             AssertEx.EqualTolerance(UsCustomaryCupsInOneCubicMeter, cubicmeter.UsCustomaryCups, UsCustomaryCupsTolerance);
@@ -188,7 +188,7 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, Volume.From(1, VolumeUnit.OilBarrel).OilBarrels, OilBarrelsTolerance);
             AssertEx.EqualTolerance(1, Volume.From(1, VolumeUnit.Tablespoon).Tablespoons, TablespoonsTolerance);
             AssertEx.EqualTolerance(1, Volume.From(1, VolumeUnit.Teaspoon).Teaspoons, TeaspoonsTolerance);
-            AssertEx.EqualTolerance(1, Volume.From(1, VolumeUnit.UkBeerBarrel).UkBeerBarrels, UkBeerBarrelsTolerance);
+            AssertEx.EqualTolerance(1, Volume.From(1, VolumeUnit.ImperialBeerBarrel).ImperialBeerBarrels, ImperialBeerBarrelsTolerance);
             AssertEx.EqualTolerance(1, Volume.From(1, VolumeUnit.UkTablespoon).UkTablespoons, UkTablespoonsTolerance);
             AssertEx.EqualTolerance(1, Volume.From(1, VolumeUnit.UsBeerBarrel).UsBeerBarrels, UsBeerBarrelsTolerance);
             AssertEx.EqualTolerance(1, Volume.From(1, VolumeUnit.UsCustomaryCup).UsCustomaryCups, UsCustomaryCupsTolerance);
@@ -227,7 +227,7 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(OilBarrelsInOneCubicMeter, cubicmeter.As(VolumeUnit.OilBarrel), OilBarrelsTolerance);
             AssertEx.EqualTolerance(TablespoonsInOneCubicMeter, cubicmeter.As(VolumeUnit.Tablespoon), TablespoonsTolerance);
             AssertEx.EqualTolerance(TeaspoonsInOneCubicMeter, cubicmeter.As(VolumeUnit.Teaspoon), TeaspoonsTolerance);
-            AssertEx.EqualTolerance(UkBeerBarrelsInOneCubicMeter, cubicmeter.As(VolumeUnit.UkBeerBarrel), UkBeerBarrelsTolerance);
+            AssertEx.EqualTolerance(ImperialBeerBarrelsInOneCubicMeter, cubicmeter.As(VolumeUnit.ImperialBeerBarrel), ImperialBeerBarrelsTolerance);
             AssertEx.EqualTolerance(UkTablespoonsInOneCubicMeter, cubicmeter.As(VolumeUnit.UkTablespoon), UkTablespoonsTolerance);
             AssertEx.EqualTolerance(UsBeerBarrelsInOneCubicMeter, cubicmeter.As(VolumeUnit.UsBeerBarrel), UsBeerBarrelsTolerance);
             AssertEx.EqualTolerance(UsCustomaryCupsInOneCubicMeter, cubicmeter.As(VolumeUnit.UsCustomaryCup), UsCustomaryCupsTolerance);
@@ -266,7 +266,7 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, Volume.FromOilBarrels(cubicmeter.OilBarrels).CubicMeters, OilBarrelsTolerance);
             AssertEx.EqualTolerance(1, Volume.FromTablespoons(cubicmeter.Tablespoons).CubicMeters, TablespoonsTolerance);
             AssertEx.EqualTolerance(1, Volume.FromTeaspoons(cubicmeter.Teaspoons).CubicMeters, TeaspoonsTolerance);
-            AssertEx.EqualTolerance(1, Volume.FromUkBeerBarrels(cubicmeter.UkBeerBarrels).CubicMeters, UkBeerBarrelsTolerance);
+            AssertEx.EqualTolerance(1, Volume.FromImperialBeerBarrels(cubicmeter.ImperialBeerBarrels).CubicMeters, ImperialBeerBarrelsTolerance);
             AssertEx.EqualTolerance(1, Volume.FromUkTablespoons(cubicmeter.UkTablespoons).CubicMeters, UkTablespoonsTolerance);
             AssertEx.EqualTolerance(1, Volume.FromUsBeerBarrels(cubicmeter.UsBeerBarrels).CubicMeters, UsBeerBarrelsTolerance);
             AssertEx.EqualTolerance(1, Volume.FromUsCustomaryCups(cubicmeter.UsCustomaryCups).CubicMeters, UsCustomaryCupsTolerance);

--- a/UnitsNet/GeneratedCode/Enums/VolumeUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Enums/VolumeUnit.g.cs
@@ -68,7 +68,7 @@ namespace UnitsNet.Units
         Tablespoon,
         [System.Obsolete("Deprecated due to github issue #134, please use UsTeaspoon instead")]
         Teaspoon,
-        UkBeerBarrel,
+        ImperialBeerBarrel,
         UkTablespoon,
         UsBeerBarrel,
         UsCustomaryCup,

--- a/UnitsNet/GeneratedCode/Enums/VolumeUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Enums/VolumeUnit.g.cs
@@ -68,7 +68,9 @@ namespace UnitsNet.Units
         Tablespoon,
         [System.Obsolete("Deprecated due to github issue #134, please use UsTeaspoon instead")]
         Teaspoon,
+        UkBeerBarrel,
         UkTablespoon,
+        UsBeerBarrel,
         UsCustomaryCup,
         UsGallon,
         UsLegalCup,

--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToVolumeExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToVolumeExtensions.g.cs
@@ -860,6 +860,40 @@ namespace UnitsNet.Extensions.NumberToVolume
 
         #endregion
 
+        #region UkBeerBarrel
+
+        /// <inheritdoc cref="Volume.FromUkBeerBarrels(double)"/>
+        public static Volume UkBeerBarrels(this int value) => Volume.FromUkBeerBarrels(value);
+
+        /// <inheritdoc cref="Volume.FromUkBeerBarrels(double?)"/>
+        public static Volume? UkBeerBarrels(this int? value) => Volume.FromUkBeerBarrels(value);
+
+        /// <inheritdoc cref="Volume.FromUkBeerBarrels(double)"/>
+        public static Volume UkBeerBarrels(this long value) => Volume.FromUkBeerBarrels(value);
+
+        /// <inheritdoc cref="Volume.FromUkBeerBarrels(double?)"/>
+        public static Volume? UkBeerBarrels(this long? value) => Volume.FromUkBeerBarrels(value);
+
+        /// <inheritdoc cref="Volume.FromUkBeerBarrels(double)"/>
+        public static Volume UkBeerBarrels(this double value) => Volume.FromUkBeerBarrels(value);
+
+        /// <inheritdoc cref="Volume.FromUkBeerBarrels(double?)"/>
+        public static Volume? UkBeerBarrels(this double? value) => Volume.FromUkBeerBarrels(value);
+
+        /// <inheritdoc cref="Volume.FromUkBeerBarrels(double)"/>
+        public static Volume UkBeerBarrels(this float value) => Volume.FromUkBeerBarrels(value);
+
+        /// <inheritdoc cref="Volume.FromUkBeerBarrels(double?)"/>
+        public static Volume? UkBeerBarrels(this float? value) => Volume.FromUkBeerBarrels(value);
+
+        /// <inheritdoc cref="Volume.FromUkBeerBarrels(double)"/>
+        public static Volume UkBeerBarrels(this decimal value) => Volume.FromUkBeerBarrels(Convert.ToDouble(value));
+
+        /// <inheritdoc cref="Volume.FromUkBeerBarrels(double?)"/>
+        public static Volume? UkBeerBarrels(this decimal? value) => Volume.FromUkBeerBarrels(value == null ? (double?)null : Convert.ToDouble(value.Value));
+
+        #endregion
+
         #region UkTablespoon
 
         /// <inheritdoc cref="Volume.FromUkTablespoons(double)"/>
@@ -891,6 +925,40 @@ namespace UnitsNet.Extensions.NumberToVolume
 
         /// <inheritdoc cref="Volume.FromUkTablespoons(double?)"/>
         public static Volume? UkTablespoons(this decimal? value) => Volume.FromUkTablespoons(value == null ? (double?)null : Convert.ToDouble(value.Value));
+
+        #endregion
+
+        #region UsBeerBarrel
+
+        /// <inheritdoc cref="Volume.FromUsBeerBarrels(double)"/>
+        public static Volume UsBeerBarrels(this int value) => Volume.FromUsBeerBarrels(value);
+
+        /// <inheritdoc cref="Volume.FromUsBeerBarrels(double?)"/>
+        public static Volume? UsBeerBarrels(this int? value) => Volume.FromUsBeerBarrels(value);
+
+        /// <inheritdoc cref="Volume.FromUsBeerBarrels(double)"/>
+        public static Volume UsBeerBarrels(this long value) => Volume.FromUsBeerBarrels(value);
+
+        /// <inheritdoc cref="Volume.FromUsBeerBarrels(double?)"/>
+        public static Volume? UsBeerBarrels(this long? value) => Volume.FromUsBeerBarrels(value);
+
+        /// <inheritdoc cref="Volume.FromUsBeerBarrels(double)"/>
+        public static Volume UsBeerBarrels(this double value) => Volume.FromUsBeerBarrels(value);
+
+        /// <inheritdoc cref="Volume.FromUsBeerBarrels(double?)"/>
+        public static Volume? UsBeerBarrels(this double? value) => Volume.FromUsBeerBarrels(value);
+
+        /// <inheritdoc cref="Volume.FromUsBeerBarrels(double)"/>
+        public static Volume UsBeerBarrels(this float value) => Volume.FromUsBeerBarrels(value);
+
+        /// <inheritdoc cref="Volume.FromUsBeerBarrels(double?)"/>
+        public static Volume? UsBeerBarrels(this float? value) => Volume.FromUsBeerBarrels(value);
+
+        /// <inheritdoc cref="Volume.FromUsBeerBarrels(double)"/>
+        public static Volume UsBeerBarrels(this decimal value) => Volume.FromUsBeerBarrels(Convert.ToDouble(value));
+
+        /// <inheritdoc cref="Volume.FromUsBeerBarrels(double?)"/>
+        public static Volume? UsBeerBarrels(this decimal? value) => Volume.FromUsBeerBarrels(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Extensions/Number/NumberToVolumeExtensions.g.cs
+++ b/UnitsNet/GeneratedCode/Extensions/Number/NumberToVolumeExtensions.g.cs
@@ -860,37 +860,37 @@ namespace UnitsNet.Extensions.NumberToVolume
 
         #endregion
 
-        #region UkBeerBarrel
+        #region ImperialBeerBarrel
 
-        /// <inheritdoc cref="Volume.FromUkBeerBarrels(double)"/>
-        public static Volume UkBeerBarrels(this int value) => Volume.FromUkBeerBarrels(value);
+        /// <inheritdoc cref="Volume.FromImperialBeerBarrels(double)"/>
+        public static Volume ImperialBeerBarrels(this int value) => Volume.FromImperialBeerBarrels(value);
 
-        /// <inheritdoc cref="Volume.FromUkBeerBarrels(double?)"/>
-        public static Volume? UkBeerBarrels(this int? value) => Volume.FromUkBeerBarrels(value);
+        /// <inheritdoc cref="Volume.FromImperialBeerBarrels(double?)"/>
+        public static Volume? ImperialBeerBarrels(this int? value) => Volume.FromImperialBeerBarrels(value);
 
-        /// <inheritdoc cref="Volume.FromUkBeerBarrels(double)"/>
-        public static Volume UkBeerBarrels(this long value) => Volume.FromUkBeerBarrels(value);
+        /// <inheritdoc cref="Volume.FromImperialBeerBarrels(double)"/>
+        public static Volume ImperialBeerBarrels(this long value) => Volume.FromImperialBeerBarrels(value);
 
-        /// <inheritdoc cref="Volume.FromUkBeerBarrels(double?)"/>
-        public static Volume? UkBeerBarrels(this long? value) => Volume.FromUkBeerBarrels(value);
+        /// <inheritdoc cref="Volume.FromImperialBeerBarrels(double?)"/>
+        public static Volume? ImperialBeerBarrels(this long? value) => Volume.FromImperialBeerBarrels(value);
 
-        /// <inheritdoc cref="Volume.FromUkBeerBarrels(double)"/>
-        public static Volume UkBeerBarrels(this double value) => Volume.FromUkBeerBarrels(value);
+        /// <inheritdoc cref="Volume.FromImperialBeerBarrels(double)"/>
+        public static Volume ImperialBeerBarrels(this double value) => Volume.FromImperialBeerBarrels(value);
 
-        /// <inheritdoc cref="Volume.FromUkBeerBarrels(double?)"/>
-        public static Volume? UkBeerBarrels(this double? value) => Volume.FromUkBeerBarrels(value);
+        /// <inheritdoc cref="Volume.FromImperialBeerBarrels(double?)"/>
+        public static Volume? ImperialBeerBarrels(this double? value) => Volume.FromImperialBeerBarrels(value);
 
-        /// <inheritdoc cref="Volume.FromUkBeerBarrels(double)"/>
-        public static Volume UkBeerBarrels(this float value) => Volume.FromUkBeerBarrels(value);
+        /// <inheritdoc cref="Volume.FromImperialBeerBarrels(double)"/>
+        public static Volume ImperialBeerBarrels(this float value) => Volume.FromImperialBeerBarrels(value);
 
-        /// <inheritdoc cref="Volume.FromUkBeerBarrels(double?)"/>
-        public static Volume? UkBeerBarrels(this float? value) => Volume.FromUkBeerBarrels(value);
+        /// <inheritdoc cref="Volume.FromImperialBeerBarrels(double?)"/>
+        public static Volume? ImperialBeerBarrels(this float? value) => Volume.FromImperialBeerBarrels(value);
 
-        /// <inheritdoc cref="Volume.FromUkBeerBarrels(double)"/>
-        public static Volume UkBeerBarrels(this decimal value) => Volume.FromUkBeerBarrels(Convert.ToDouble(value));
+        /// <inheritdoc cref="Volume.FromImperialBeerBarrels(double)"/>
+        public static Volume ImperialBeerBarrels(this decimal value) => Volume.FromImperialBeerBarrels(Convert.ToDouble(value));
 
-        /// <inheritdoc cref="Volume.FromUkBeerBarrels(double?)"/>
-        public static Volume? UkBeerBarrels(this decimal? value) => Volume.FromUkBeerBarrels(value == null ? (double?)null : Convert.ToDouble(value.Value));
+        /// <inheritdoc cref="Volume.FromImperialBeerBarrels(double?)"/>
+        public static Volume? ImperialBeerBarrels(this decimal? value) => Volume.FromImperialBeerBarrels(value == null ? (double?)null : Convert.ToDouble(value.Value));
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/UnitClasses/Volume.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/Volume.g.cs
@@ -324,11 +324,27 @@ namespace UnitsNet
         }
 
         /// <summary>
+        ///     Get Volume in UkBeerBarrels.
+        /// </summary>
+        public double UkBeerBarrels
+        {
+            get { return _cubicMeters/0.16365924; }
+        }
+
+        /// <summary>
         ///     Get Volume in UkTablespoons.
         /// </summary>
         public double UkTablespoons
         {
             get { return _cubicMeters/1.5e-5; }
+        }
+
+        /// <summary>
+        ///     Get Volume in UsBeerBarrels.
+        /// </summary>
+        public double UsBeerBarrels
+        {
+            get { return _cubicMeters/0.1173477658; }
         }
 
         /// <summary>
@@ -581,11 +597,27 @@ namespace UnitsNet
         }
 
         /// <summary>
+        ///     Get Volume from UkBeerBarrels.
+        /// </summary>
+        public static Volume FromUkBeerBarrels(double ukbeerbarrels)
+        {
+            return new Volume(ukbeerbarrels*0.16365924);
+        }
+
+        /// <summary>
         ///     Get Volume from UkTablespoons.
         /// </summary>
         public static Volume FromUkTablespoons(double uktablespoons)
         {
             return new Volume(uktablespoons*1.5e-5);
+        }
+
+        /// <summary>
+        ///     Get Volume from UsBeerBarrels.
+        /// </summary>
+        public static Volume FromUsBeerBarrels(double usbeerbarrels)
+        {
+            return new Volume(usbeerbarrels*0.1173477658);
         }
 
         /// <summary>
@@ -999,6 +1031,21 @@ namespace UnitsNet
         }
 
         /// <summary>
+        ///     Get nullable Volume from nullable UkBeerBarrels.
+        /// </summary>
+        public static Volume? FromUkBeerBarrels(double? ukbeerbarrels)
+        {
+            if (ukbeerbarrels.HasValue)
+            {
+                return FromUkBeerBarrels(ukbeerbarrels.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
         ///     Get nullable Volume from nullable UkTablespoons.
         /// </summary>
         public static Volume? FromUkTablespoons(double? uktablespoons)
@@ -1006,6 +1053,21 @@ namespace UnitsNet
             if (uktablespoons.HasValue)
             {
                 return FromUkTablespoons(uktablespoons.Value);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
+        ///     Get nullable Volume from nullable UsBeerBarrels.
+        /// </summary>
+        public static Volume? FromUsBeerBarrels(double? usbeerbarrels)
+        {
+            if (usbeerbarrels.HasValue)
+            {
+                return FromUsBeerBarrels(usbeerbarrels.Value);
             }
             else
             {
@@ -1163,8 +1225,12 @@ namespace UnitsNet
                     return FromTablespoons(val);
                 case VolumeUnit.Teaspoon:
                     return FromTeaspoons(val);
+                case VolumeUnit.UkBeerBarrel:
+                    return FromUkBeerBarrels(val);
                 case VolumeUnit.UkTablespoon:
                     return FromUkTablespoons(val);
+                case VolumeUnit.UsBeerBarrel:
+                    return FromUsBeerBarrels(val);
                 case VolumeUnit.UsCustomaryCup:
                     return FromUsCustomaryCups(val);
                 case VolumeUnit.UsGallon:
@@ -1247,8 +1313,12 @@ namespace UnitsNet
                     return FromTablespoons(value.Value);
                 case VolumeUnit.Teaspoon:
                     return FromTeaspoons(value.Value);
+                case VolumeUnit.UkBeerBarrel:
+                    return FromUkBeerBarrels(value.Value);
                 case VolumeUnit.UkTablespoon:
                     return FromUkTablespoons(value.Value);
+                case VolumeUnit.UsBeerBarrel:
+                    return FromUsBeerBarrels(value.Value);
                 case VolumeUnit.UsCustomaryCup:
                     return FromUsCustomaryCups(value.Value);
                 case VolumeUnit.UsGallon:
@@ -1466,8 +1536,12 @@ namespace UnitsNet
                     return Tablespoons;
                 case VolumeUnit.Teaspoon:
                     return Teaspoons;
+                case VolumeUnit.UkBeerBarrel:
+                    return UkBeerBarrels;
                 case VolumeUnit.UkTablespoon:
                     return UkTablespoons;
+                case VolumeUnit.UsBeerBarrel:
+                    return UsBeerBarrels;
                 case VolumeUnit.UsCustomaryCup:
                     return UsCustomaryCups;
                 case VolumeUnit.UsGallon:

--- a/UnitsNet/GeneratedCode/UnitClasses/Volume.g.cs
+++ b/UnitsNet/GeneratedCode/UnitClasses/Volume.g.cs
@@ -324,9 +324,9 @@ namespace UnitsNet
         }
 
         /// <summary>
-        ///     Get Volume in UkBeerBarrels.
+        ///     Get Volume in ImperialBeerBarrels.
         /// </summary>
-        public double UkBeerBarrels
+        public double ImperialBeerBarrels
         {
             get { return _cubicMeters/0.16365924; }
         }
@@ -597,9 +597,9 @@ namespace UnitsNet
         }
 
         /// <summary>
-        ///     Get Volume from UkBeerBarrels.
+        ///     Get Volume from ImperialBeerBarrels.
         /// </summary>
-        public static Volume FromUkBeerBarrels(double ukbeerbarrels)
+        public static Volume FromImperialBeerBarrels(double ukbeerbarrels)
         {
             return new Volume(ukbeerbarrels*0.16365924);
         }
@@ -1031,13 +1031,13 @@ namespace UnitsNet
         }
 
         /// <summary>
-        ///     Get nullable Volume from nullable UkBeerBarrels.
+        ///     Get nullable Volume from nullable ImperialBeerBarrels.
         /// </summary>
-        public static Volume? FromUkBeerBarrels(double? ukbeerbarrels)
+        public static Volume? FromImperialBeerBarrels(double? ukbeerbarrels)
         {
             if (ukbeerbarrels.HasValue)
             {
-                return FromUkBeerBarrels(ukbeerbarrels.Value);
+                return FromImperialBeerBarrels(ukbeerbarrels.Value);
             }
             else
             {
@@ -1225,8 +1225,8 @@ namespace UnitsNet
                     return FromTablespoons(val);
                 case VolumeUnit.Teaspoon:
                     return FromTeaspoons(val);
-                case VolumeUnit.UkBeerBarrel:
-                    return FromUkBeerBarrels(val);
+                case VolumeUnit.ImperialBeerBarrel:
+                    return FromImperialBeerBarrels(val);
                 case VolumeUnit.UkTablespoon:
                     return FromUkTablespoons(val);
                 case VolumeUnit.UsBeerBarrel:
@@ -1313,8 +1313,8 @@ namespace UnitsNet
                     return FromTablespoons(value.Value);
                 case VolumeUnit.Teaspoon:
                     return FromTeaspoons(value.Value);
-                case VolumeUnit.UkBeerBarrel:
-                    return FromUkBeerBarrels(value.Value);
+                case VolumeUnit.ImperialBeerBarrel:
+                    return FromImperialBeerBarrels(value.Value);
                 case VolumeUnit.UkTablespoon:
                     return FromUkTablespoons(value.Value);
                 case VolumeUnit.UsBeerBarrel:
@@ -1536,8 +1536,8 @@ namespace UnitsNet
                     return Tablespoons;
                 case VolumeUnit.Teaspoon:
                     return Teaspoons;
-                case VolumeUnit.UkBeerBarrel:
-                    return UkBeerBarrels;
+                case VolumeUnit.ImperialBeerBarrel:
+                    return ImperialBeerBarrels;
                 case VolumeUnit.UkTablespoon:
                     return UkTablespoons;
                 case VolumeUnit.UsBeerBarrel:

--- a/UnitsNet/GeneratedCode/UnitSystem.Default.g.cs
+++ b/UnitsNet/GeneratedCode/UnitSystem.Default.g.cs
@@ -2896,7 +2896,7 @@ namespace UnitsNet
                                 new AbbreviationsForCulture("ru-RU", "чайная ложка"),
                                 new AbbreviationsForCulture("nb-NO", "ts", "ts."),
                             }),
-                        new CulturesForEnumValue((int) VolumeUnit.UkBeerBarrel,
+                        new CulturesForEnumValue((int) VolumeUnit.ImperialBeerBarrel,
                             new[]
                             {
                                 new AbbreviationsForCulture("en-US", "bl (imp.)"),
@@ -2911,7 +2911,7 @@ namespace UnitsNet
                         new CulturesForEnumValue((int) VolumeUnit.UsBeerBarrel,
                             new[]
                             {
-                                new AbbreviationsForCulture("en-US", "bl (US)"),
+                                new AbbreviationsForCulture("en-US", "bl (U.S.)"),
                             }),
                         new CulturesForEnumValue((int) VolumeUnit.UsCustomaryCup,
                             new[]

--- a/UnitsNet/GeneratedCode/UnitSystem.Default.g.cs
+++ b/UnitsNet/GeneratedCode/UnitSystem.Default.g.cs
@@ -2896,12 +2896,22 @@ namespace UnitsNet
                                 new AbbreviationsForCulture("ru-RU", "чайная ложка"),
                                 new AbbreviationsForCulture("nb-NO", "ts", "ts."),
                             }),
+                        new CulturesForEnumValue((int) VolumeUnit.UkBeerBarrel,
+                            new[]
+                            {
+                                new AbbreviationsForCulture("en-US", "bl (imp.)"),
+                            }),
                         new CulturesForEnumValue((int) VolumeUnit.UkTablespoon,
                             new[]
                             {
                                 new AbbreviationsForCulture("en-US", ""),
                                 new AbbreviationsForCulture("ru-RU", ""),
                                 new AbbreviationsForCulture("nb-NO", ""),
+                            }),
+                        new CulturesForEnumValue((int) VolumeUnit.UsBeerBarrel,
+                            new[]
+                            {
+                                new AbbreviationsForCulture("en-US", "bl (US)"),
                             }),
                         new CulturesForEnumValue((int) VolumeUnit.UsCustomaryCup,
                             new[]

--- a/UnitsNet/UnitDefinitions/Volume.json
+++ b/UnitsNet/UnitDefinitions/Volume.json
@@ -295,15 +295,15 @@
       "Localization": [
         {
           "Culture": "en-US",
-          "Abbreviations": [ ]
+          "Abbreviations": []
         },
         {
           "Culture": "ru-RU",
-          "Abbreviations": [ ]
+          "Abbreviations": []
         },
         {
           "Culture": "nb-NO",
-          "Abbreviations": [ ]
+          "Abbreviations": []
         }
       ]
     },
@@ -315,15 +315,15 @@
       "Localization": [
         {
           "Culture": "en-US",
-          "Abbreviations": [ ]
+          "Abbreviations": []
         },
         {
           "Culture": "ru-RU",
-          "Abbreviations": [ ]
+          "Abbreviations": []
         },
         {
           "Culture": "nb-NO",
-          "Abbreviations": [ ]
+          "Abbreviations": []
         }
       ]
     },
@@ -335,15 +335,15 @@
       "Localization": [
         {
           "Culture": "en-US",
-          "Abbreviations": [ ]
+          "Abbreviations": []
         },
         {
           "Culture": "ru-RU",
-          "Abbreviations": [ ]
+          "Abbreviations": []
         },
         {
           "Culture": "nb-NO",
-          "Abbreviations": [ ]
+          "Abbreviations": []
         }
       ]
     },
@@ -359,11 +359,11 @@
         },
         {
           "Culture": "ru-RU",
-          "Abbreviations": [ ]
+          "Abbreviations": []
         },
         {
           "Culture": "nb-NO",
-          "Abbreviations": [ ]
+          "Abbreviations": []
         }
       ]
     },
@@ -375,15 +375,15 @@
       "Localization": [
         {
           "Culture": "en-US",
-          "Abbreviations": [ ]
+          "Abbreviations": []
         },
         {
           "Culture": "ru-RU",
-          "Abbreviations": [ ]
+          "Abbreviations": []
         },
         {
           "Culture": "nb-NO",
-          "Abbreviations": [ ]
+          "Abbreviations": []
         }
       ]
     },
@@ -395,7 +395,7 @@
       "Localization": [
         {
           "Culture": "en-US",
-          "Abbreviations": [ ]
+          "Abbreviations": []
         }
       ]
     },
@@ -407,7 +407,7 @@
       "Localization": [
         {
           "Culture": "en-US",
-          "Abbreviations": [ ]
+          "Abbreviations": []
         }
       ]
     },
@@ -419,7 +419,7 @@
       "Localization": [
         {
           "Culture": "en-US",
-          "Abbreviations": [ ]
+          "Abbreviations": []
         }
       ]
     },
@@ -432,6 +432,30 @@
         {
           "Culture": "en-US",
           "Abbreviations": [ "bbl" ]
+        }
+      ]
+    },
+    {
+      "SingularName": "UsBeerBarrel",
+      "PluralName": "UsBeerBarrels",
+      "FromUnitToBaseFunc": "x*0.1173477658",
+      "FromBaseToUnitFunc": "x/0.1173477658",
+      "Localization": [
+        {
+          "Culture": "en-US",
+          "Abbreviations": [ "bl (US)" ]
+        }
+      ]
+    },
+    {
+      "SingularName": "UkBeerBarrel",
+      "PluralName": "UkBeerBarrels",
+      "FromUnitToBaseFunc": "x*0.16365924",
+      "FromBaseToUnitFunc": "x/0.16365924",
+      "Localization": [
+        {
+          "Culture": "en-US",
+          "Abbreviations": [ "bl (imp.)" ]
         }
       ]
     }

--- a/UnitsNet/UnitDefinitions/Volume.json
+++ b/UnitsNet/UnitDefinitions/Volume.json
@@ -443,13 +443,13 @@
       "Localization": [
         {
           "Culture": "en-US",
-          "Abbreviations": [ "bl (US)" ]
+          "Abbreviations": [ "bl (U.S.)" ]
         }
       ]
     },
     {
-      "SingularName": "UkBeerBarrel",
-      "PluralName": "UkBeerBarrels",
+      "SingularName": "ImperialBeerBarrel",
+      "PluralName": "ImperialBeerBarrels",
       "FromUnitToBaseFunc": "x*0.16365924",
       "FromBaseToUnitFunc": "x/0.16365924",
       "Localization": [


### PR DESCRIPTION
Barrels are extremely confusing.

US Oil Barel was alright in Units.Net. It is 42 US Gal, with abbreviation "bbl".

I added UK Beer Barrel which is 36 UK Gal, with abbreviation "bl (imp.)".

I added US Beer Barrel which is 31 US Gal, with abbreviation "bl (US)".

All three use the "bbl" as their abbreviation, so I wasn't sure what to do there... It seems BBL is more associated with oil, and I have seen 'bl' for beer.  My pref would be to just use "bbl" for all 3, as they are unlikely be used in the same application. But I don't think you can have them the same.
